### PR TITLE
bugfix: Fatal Python error: deallocating None

### DIFF
--- a/cardenc/pycard.cc
+++ b/cardenc/pycard.cc
@@ -268,13 +268,15 @@ static PyObject *py_encode_atmost(PyObject *self, PyObject *args)
 		PyList_SetItem(dest_obj, i, cl_obj);
 	}
 
-	PyObject *ret = Py_None;
-
-	if (dest.size())
-		ret = Py_BuildValue("On", dest_obj, (Py_ssize_t)top);
-
-	Py_DECREF(dest_obj);
-	return ret;
+	if (dest.size()){
+		PyObject *ret = Py_BuildValue("On", dest_obj, (Py_ssize_t)top);
+		Py_DECREF(dest_obj);
+		return ret;
+	}
+	else{
+		Py_DECREF(dest_obj);
+		Py_RETURN_NONE;
+	}
 }
 
 //
@@ -317,13 +319,18 @@ static PyObject *py_encode_atleast(PyObject *self, PyObject *args)
 		PyList_SetItem(dest_obj, i, cl_obj);
 	}
 
-	PyObject *ret = Py_None;
 
-	if (dest.size())
-		ret = Py_BuildValue("On", dest_obj, (Py_ssize_t)top);
+	if (dest.size()){
+		PyObject *ret = Py_BuildValue("On", dest_obj, (Py_ssize_t)top);
+		Py_DECREF(dest_obj);
+		return ret;
 
-	Py_DECREF(dest_obj);
-	return ret;
+	}
+	else{
+		Py_DECREF(dest_obj);
+		Py_RETURN_NONE;
+	}
+
 }
 
 //
@@ -537,15 +544,21 @@ static PyObject *py_itot_mrg(PyObject *self, PyObject *args)
 		PyList_SetItem(ubs_obj, i, ub_obj);
 	}
 
-	PyObject *ret = Py_None;
+	 
 
-	if (dest.size())
-		ret = Py_BuildValue("OOOn", void_to_pyobj((void *)tree1),
-				dest_obj, ubs_obj, (Py_ssize_t)top);
+	if (dest.size()){
+		PyObject *ret = Py_BuildValue("OOOn", void_to_pyobj((void *)tree1),
+				dest_obj, ubs_obj, (Py_ssize_t)top);		
+		Py_DECREF(dest_obj);
+		Py_DECREF( ubs_obj);
+		return ret;
+	}
+	else{
+		Py_DECREF(dest_obj);
+		Py_DECREF( ubs_obj);
+		Py_RETURN_NONE;
+	}
 
-	Py_DECREF(dest_obj);
-	Py_DECREF( ubs_obj);
-	return ret;
 }
 
 //


### PR DESCRIPTION
Got the following error while creating multiple SAT instances "Fatal Python error: deallocating None" and fixed it.
https://stackoverflow.com/questions/15287590/why-should-py-increfpy-none-be-required-before-returning-py-none-in-c