### PR TITLE
WCNF and WCNFPlus to_file bug fix

### DIFF
--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -1098,6 +1098,8 @@ class WCNF(object):
         self.nv = max([abs(l) for l in clause] + [self.nv])
 
         if weight:
+            if weight >= self.topw:
+                self.topw = weight+1
             self.soft.append(clause)
             self.wght.append(weight)
         else:
@@ -1593,6 +1595,8 @@ class WCNFPlus(WCNF, object):
             self.nv = max([abs(l) for l in clause] + [self.nv])
 
             if weight:
+                if weight >= self.topw:
+                    self.topw = weight + 1
                 self.soft.append(clause)
                 self.wght.append(weight)
             else:

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -814,7 +814,7 @@ class WCNF(object):
         self.hard = []
         self.soft = []
         self.wght = []
-        self.topw = 0
+        self.topw = 1
         self.comments = []
 
         if from_file:
@@ -1098,8 +1098,7 @@ class WCNF(object):
         self.nv = max([abs(l) for l in clause] + [self.nv])
 
         if weight:
-            if weight >= self.topw:
-                self.topw = weight+1
+            self.topw += weight
             self.soft.append(clause)
             self.wght.append(weight)
         else:
@@ -1595,8 +1594,7 @@ class WCNFPlus(WCNF, object):
             self.nv = max([abs(l) for l in clause] + [self.nv])
 
             if weight:
-                if weight >= self.topw:
-                    self.topw = weight + 1
+                self.topw += weight
                 self.soft.append(clause)
                 self.wght.append(weight)
             else:


### PR DESCRIPTION
Hard clauses were getting a weight of 0 when dumped to a .wcnf file through the to_file method. The top weight value wasn't being updated when a soft clause was added using append.