### PR TITLE
Depend on py-aiger-cnf instead of directly on py-aiger.

### DIFF
--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -605,14 +605,16 @@ class CNF(object):
         """
         assert aiger_present, 'Package \'py-aiger\' is unavailable. Check your installation.'
 
+        # resetting the formula
+        self.clauses, self.nv = [], 0
+
         # creating a pool of variable IDs if necessary
         self.vpool = vpool if vpool else IDPool()
 
         # Use py-aiger-cnf to insulate from internal py-aiger details.
         aig_cnf = aiger_cnf.aig2cnf(aig, fresh=self.vpool.id, force_true=False)
-
-        # resetting the formula
-        self.clauses, self.nv = [], 0
+        
+        self.clauses = [list(cls) for cls in aig_cnf.clauses]
         self.comments = ['c ' + c.strip() for c in aig_cnf.comments]
 
         # saving input and output variables

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-py-aiger>=3.3.0
+py-aiger-cnf>=2.0.0
 pypblib>=0.0.3
 six

--- a/setup.py
+++ b/setup.py
@@ -115,5 +115,5 @@ setup(name='python-sat',
     ext_modules=[pycard_ext, pysolvers_ext],
     scripts=['examples/{0}.py'.format(s) for s in scripts],
     cmdclass={'build': build},
-    install_requires=['py-aiger>=3.3.0', 'pypblib>=0.0.3', 'six']
+    install_requires=['py-aiger-cnf>=2.0.0', 'pypblib>=0.0.3', 'six']
 )


### PR DESCRIPTION
Addresses issue #21.

Marked as draft until some more details are worked out such as:

1. What is the best way to test. The code seems to produce the same results as the docstring example suggests it should.
2. What is the best way to force the outputs to be true? An `aiger.BoolExpr` encodes a predicate. I would like to be able to simple send this expression into `pysat` and find solutions that make this predicate True.