### PR TITLE
From aiger count nv

### DIFF
--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -610,9 +610,7 @@ class CNF(object):
         
         self.clauses = [list(cls) for cls in aig_cnf.clauses]
         self.comments = ['c ' + c.strip() for c in aig_cnf.comments]
-
-        # Flatten clauses and count unique elements.
-        self.nv = len(set(itertools.chain(*self.clauses)))
+        self.nv = max(itertools.chain(*self.clauses))
 
         # saving input and output variables
         self.inps = list(aig_cnf.input2lit.values())

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -610,7 +610,7 @@ class CNF(object):
         
         self.clauses = [list(cls) for cls in aig_cnf.clauses]
         self.comments = ['c ' + c.strip() for c in aig_cnf.comments]
-        self.nv = max(itertools.chain(*self.clauses))
+        self.nv = max(map(abs, itertools.chain(*self.clauses)))
 
         # saving input and output variables
         self.inps = list(aig_cnf.input2lit.values())

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -208,6 +208,7 @@
 from __future__ import print_function
 import collections
 import copy
+import itertools
 import os
 from pysat._fileio import FileObject
 import sys
@@ -562,10 +563,6 @@ class CNF(object):
             :class:`aiger.BoolExpr` are defined in the `py-aiger package
             <https://github.com/mvcisback/py-aiger>`__.)
 
-            Note that this implementation is inspired by (and so resembles)
-            similar functinality of the `py-aiger-analysis package
-            <https://github.com/mvcisback/py-AIGAR/>`__.
-
             :param aig: an input AIGER circuit
             :param vpool: pool of variable identifiers (optional)
 
@@ -605,9 +602,6 @@ class CNF(object):
         """
         assert aiger_present, 'Package \'py-aiger\' is unavailable. Check your installation.'
 
-        # resetting the formula
-        self.clauses, self.nv = [], 0
-
         # creating a pool of variable IDs if necessary
         self.vpool = vpool if vpool else IDPool()
 
@@ -616,6 +610,9 @@ class CNF(object):
         
         self.clauses = [list(cls) for cls in aig_cnf.clauses]
         self.comments = ['c ' + c.strip() for c in aig_cnf.comments]
+
+        # Flatten clauses and count unique elements.
+        self.nv = len(set(itertools.chain(*self.clauses)))
 
         # saving input and output variables
         self.inps = list(aig_cnf.input2lit.values())


### PR DESCRIPTION
Set the number of variables attribute `CNF.nv` by computing the maximum literal seen in the clauses.

This is done by:

1. flattening the clauses using `itertools.chain`
2. taking the absolute value of each literal with `map(abs, ...)`
3. taking the `max` of the resulting sequence.

Addresses issue brought up in #21 .