### PR TITLE
Mark py-aiger-cnf as optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,5 +115,8 @@ setup(name='python-sat',
     ext_modules=[pycard_ext, pysolvers_ext],
     scripts=['examples/{0}.py'.format(s) for s in scripts],
     cmdclass={'build': build},
-    install_requires=['py-aiger-cnf>=2.0.0', 'pypblib>=0.0.3', 'six']
+    install_requires=['pypblib>=0.0.3', 'six'],
+    extras_require = {
+        'aiger': ['py-aiger-cnf>=2.0.0',],
+    },
 )


### PR DESCRIPTION
`py-aiger` and associated libraries require `python-3.6+`. `pysat` currently already treats `aiger` as an optional dependency, so this PR makes this explicit by introducing an `aiger` option to `setup.py`.

To install without `aiger` one would use:

`$ pip install python-sat`

To install with `aiger` one would use:

`$ pip install python-sat[aiger]`