### PR TITLE
fix(formula.py): catching aiger_cnf not found error

### DIFF
--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -217,7 +217,7 @@ import sys
 aiger_present = True
 try:
     import aiger_cnf
-except SyntaxError:
+except ImportError:
     aiger_present = False
 
 try:  # for Python2


### PR DESCRIPTION
If the package `aiger_cnf` is not found, it throws `ImportError` instead of `SyntaxError` in both python 2 and 3.

I think `SyntaxError` occurs while importing only when the source of the imported package has syntax error?

CC: @alexeyignatiev @mvcisback 