### PR TITLE
Calculating implicit topw in WCNF.from_fp function

### DIFF
--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -1106,14 +1106,23 @@ class WCNF(object):
                         self.wght.append(w)
                 elif not line.startswith('p wcnf '):
                     self.comments.append(line)
-                else:  # expecting the preamble
-                    self.topw = parse_wght(line.rsplit(' ', 1)[1])
+                else: # expecting the preamble
+                    preamble = line.split(' ')
+                    if len(preamble) == 5: # preamble should be "p wcnf nvars nclauses topw"
+                        self.topw = parse_wght([1])
+                    else: # preamble should be "p wcnf nvars nclauses", with topw omitted
+                        self.topw = float('inf')
 
         # if there is any soft clause with negative weight
         # normalize it, i.e. transform into a set of clauses
         # with a positive weight
         if negs:
             self.normalize_negatives(negs)
+            
+        # if topw was unspecified and assigned to infinity
+        # we'll assign it to the sum of all soft clause weights plus one
+        if decimal.is_infinite(self.topw):
+            self.topw = 1 + sum(self.wght)
 
     def normalize_negatives(self, negatives):
         """


### PR DESCRIPTION
fix #98
If no explicit topw is provided in the preamble of a WCNF problem, topw is initialized as float('inf').
After all clauses have been read, an infinity topw is replaced by a calculated one, by summing all weights plus one.