### PR TITLE
cadical.patch: avoid libc++ <version> header conflict on case-insensi…

### DIFF
--- a/solvers/patches/cadical.patch
+++ b/solvers/patches/cadical.patch
@@ -463,3 +463,9 @@ diff -Naur solvers/cadical/version.cpp solvers/cdc/version.cpp
  #endif
  
  /*------------------------------------------------------------------------*/
+diff --git solvers/cadical/VERSION solvers/cdc/VERSION
+deleted file mode 100644
+--- solvers/cadical/VERSION
++++ /dev/null
+@@ -1 +0,0 @@
+-1.0.3


### PR DESCRIPTION
…tive filesystems

compiling cadical
c++ -std=c++11 -fPIC -Wall -Wno-deprecated -fno-strict-aliasing -DQUIET -I. -O3 -DNDEBUG -c analyze.cpp -o analyze.o
In file included from analyze.cpp:1:
In file included from ./internal.hpp:10:
In file included from /nix/store/bb0bgspj580fghgzv9d9zvk5k9nn98d3-libcxx-11.1.0-dev/include/c++/v1/cmath:308:
In file included from /nix/store/bb0bgspj580fghgzv9d9zvk5k9nn98d3-libcxx-11.1.0-dev/include/c++/v1/math.h:309:
In file included from /nix/store/bb0bgspj580fghgzv9d9zvk5k9nn98d3-libcxx-11.1.0-dev/include/c++/v1/type_traits:417:
In file included from /nix/store/bb0bgspj580fghgzv9d9zvk5k9nn98d3-libcxx-11.1.0-dev/include/c++/v1/cstddef:37:
./version:1:1: error: expected unqualified-id
1.0.3
^