### PR TITLE
Fixed using RC2 with solvers which don't support the incr keyword

### DIFF
--- a/examples/rc2.py
+++ b/examples/rc2.py
@@ -275,10 +275,14 @@ class RC2(object):
             :type formula: :class:`.WCNFPlus`
             :type incr: bool
         """
+        # Only set incr kwarg if it's enabled. Some solvers don't take it as an argument
+        kwargs = {}
+        if incr:
+            kwargs["incr"] = True
 
         # creating a solver object
         self.oracle = Solver(name=self.solver, bootstrap_with=formula.hard,
-                incr=incr, use_timer=True)
+                use_timer=True, **kwargs)
 
         # adding native cardinality constraints (if any) as hard clauses
         # this can be done only if the Minicard solver is in use


### PR DESCRIPTION
I noticed a regression preventing the use of RC2 with some solvers. It comes from [these lines](https://github.com/pysathq/pysat/blob/e833ffc03ccc905e58a3552d3d7ad77c65b85520/pysat/solvers.py#L395-L400), where the kwargs was not passed to those solvers before. The simplest option seemed to be just to have RC2 omit the argument if it's not necessary.