### PR TITLE
Fixed CNF from_string example bug

### DIFF
--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -528,11 +528,11 @@ class CNF(object):
 
                 >>> from pysat.formula import CNF
                 >>> cnf1 = CNF()
-                >>> cnf1.from_string('p cnf 2 2\n-1 2 0\n1 -2 0')
+                >>> cnf1.from_string('p cnf 2 2\\n-1 2 0\\n1 -2 0')
                 >>> print(cnf1.clauses)
                 [[-1, 2], [1, -2]]
                 >>>
-                >>> cnf2 = CNF(from_string='p cnf 3 3\n-1 2 0\n-2 3 0\n-3 0\n')
+                >>> cnf2 = CNF(from_string='p cnf 3 3\\n-1 2 0\\n-2 3 0\\n-3 0\\n')
                 >>> print(cnf2.clauses)
                 [[-1, 2], [-2, 3], [-3]]
                 >>> print(cnf2.nv)

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -1179,7 +1179,7 @@ class WCNF(object):
 
                 >>> from pysat.formula import WCNF
                 >>> cnf1 = WCNF()
-                >>> cnf1.from_string(='p wcnf 2 2 2\\n 2 -1 2 0\\n1 1 -2 0')
+                >>> cnf1.from_string('p wcnf 2 2 2\\n 2 -1 2 0\\n1 1 -2 0')
                 >>> print(cnf1.hard)
                 [[-1, 2]]
                 >>> print(cnf1.soft)

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -528,11 +528,11 @@ class CNF(object):
 
                 >>> from pysat.formula import CNF
                 >>> cnf1 = CNF()
-                >>> cnf1.from_string(='p cnf 2 2\\n-1 2 0\\n1 -2 0')
+                >>> cnf1.from_string('p cnf 2 2\n-1 2 0\n1 -2 0')
                 >>> print(cnf1.clauses)
                 [[-1, 2], [1, -2]]
                 >>>
-                >>> cnf2 = CNF(from_string='p cnf 3 3\\n-1 2 0\\n-2 3 0\\n-3 0\\n')
+                >>> cnf2 = CNF(from_string='p cnf 3 3\n-1 2 0\n-2 3 0\n-3 0\n')
                 >>> print(cnf2.clauses)
                 [[-1, 2], [-2, 3], [-3]]
                 >>> print(cnf2.nv)


### PR DESCRIPTION
The example section in the CNF docstring has some bugs, including invalid syntax, which would result in no clauses actually being added.

### Before
```python3
>>> from pysat.formula import CNF
>>> cnf1 = CNF()
>>> cnf1.from_string('p cnf 2 2\\n-1 2 0\\n1 -2 0')
>>> print(cnf1.clauses)
[]
>>> cnf2 = CNF(from_string='p cnf 3 3\\n-1 2 0\\n-2 3 0\\n-3 0\\n')
>>> print(cnf2.clauses)
[]
```

### After
```python3
>>> from pysat.formula import CNF
>>> cnf1 = CNF()
>>> cnf1.from_string('p cnf 2 2\n-1 2 0\n1 -2 0')
>>> print(cnf1.clauses)
[[-1, 2], [1, -2]]
>>> cnf2 = CNF(from_string='p cnf 3 3\n-1 2 0\n-2 3 0\n-3 0\n')
>>> print(cnf2.clauses)
[[-1, 2], [-2, 3], [-3]]
```

There also seem to be similar problems in WCNF, but I am not familiar with weighted CNF and hard and soft and all that. Changing the input string also changes the example outputs. So I'm not sure what to do with them.

Not sure about CNFPlus and WCNFPlus.