### PR TITLE
Formula enhancement: added repr and to_dimacs methods to formula classes

### DIFF
--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -1065,6 +1065,13 @@ class WCNF(object):
         elif from_string:
             self.from_string(from_string, comment_lead)
 
+    def __repr__(self):
+        """
+            State reproducible string representaion of object.
+        """
+        s = self.to_dimacs().replace('\n', '\\n')
+        return f"WCNF(from_string=\"{s}\")"
+
     def from_file(self, fname, comment_lead=['c'], compressed_with='use_ext'):
         """
             Read a WCNF formula from a file in the DIMACS format. A file name
@@ -1360,6 +1367,41 @@ class WCNF(object):
 
         for cl in self.hard:
             print(self.topw, ' '.join(str(l) for l in cl), '0', file=file_pointer)
+
+    def to_dimacs(self):
+        """
+            Return the current state of the object in extended DIMACS format.
+
+            For example, if 'some-file.cnf' contains:
+
+            ::
+
+                c Example
+                p wcnf 2 3 10
+                1 -1 0
+                2 -2 0
+                10 1 2 0
+
+            Then you can obtain the DIMACS with:
+
+            .. code-block:: python
+
+                >>> from pysat.formula import CNF
+                >>> cnf = CNF(from_file='some-file.cnf')
+                >>> print(cnf.to_dimacs())
+                c Example
+                p wcnf 2 3 10
+                10 1 2 0
+                1 -1 0
+                2 -2 0
+
+        """
+        header_lines = [f"p wcnf {self.nv} {len(self.hard)+len(self.soft)} {self.topw}"]
+        comment_lines = [f"{comment}" for comment in self.comments]
+        hard_lines = [f"{self.topw} " + " ".join(map(str,clause)) + " 0" for clause in self.hard]
+        soft_lines = [f"{weight} " + " ".join(map(str,clause)) + " 0" for clause, weight in zip(self.soft, self.wght)]
+        lines = "\n".join(comment_lines + header_lines + hard_lines + soft_lines) + "\n"
+        return lines
 
     def to_alien(self, file_pointer, format='opb', comments=None):
         """

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -259,6 +259,12 @@ class IDPool(object):
 
         self.restart(start_from=start_from, occupied=occupied)
 
+    def __repr__(self):
+        """
+            State reproducible string representaion of object.
+        """
+        return f"IDPool(start_from={self.top+1}, occupied={self._occupied})"
+
     def restart(self, start_from=1, occupied=[]):
         """
             Restart the manager from scratch. The arguments replicate those of
@@ -432,6 +438,12 @@ class CNF(object):
             self.from_clauses(from_clauses)
         elif from_aiger:
             self.from_aiger(from_aiger)
+
+    def __repr__(self):
+        """
+            State reproducible string representaion of object.
+        """
+        return f"CNF(from_clauses={self.clauses})"
 
     def from_file(self, fname, comment_lead=['c'], compressed_with='use_ext'):
         """

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -755,10 +755,11 @@ class CNF(object):
 
             ::
 
-                c Example file
-                p cnf 3 2
+                c Example
+                p cnf 3 3
                 -1 2 0
                 -2 3 0
+                -3 0
 
             Then you can obtain the DIMACS with:
 
@@ -767,7 +768,7 @@ class CNF(object):
                 >>> from pysat.formula import CNF
                 >>> cnf = CNF(from_file='some-file.cnf')
                 >>> print(cnf.to_dimacs())
-                c Example: Two cardinality constraints followed by a clause
+                c Example
                 p cnf 3 3
                 -1 2 0
                 -2 3 0

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -1386,8 +1386,8 @@ class WCNF(object):
 
             .. code-block:: python
 
-                >>> from pysat.formula import CNF
-                >>> cnf = CNF(from_file='some-file.cnf')
+                >>> from pysat.formula import WCNF
+                >>> cnf = WCNF(from_file='some-file.cnf')
                 >>> print(cnf.to_dimacs())
                 c Example
                 p wcnf 2 3 10
@@ -1806,8 +1806,8 @@ class CNFPlus(CNF, object):
 
             .. code-block:: python
 
-                >>> from pysat.formula import CNF
-                >>> cnf = CNF(from_file='some-file.cnf')
+                >>> from pysat.formula import CNFPlus
+                >>> cnf = CNFPlus(from_file='some-file.cnf')
                 >>> print(cnf.to_dimacs())
                 c Example
                 p cnf+ 7 3
@@ -2324,8 +2324,8 @@ class WCNFPlus(WCNF, object):
 
             .. code-block:: python
 
-                >>> from pysat.formula import CNF
-                >>> cnf = CNF(from_file='some-file.cnf')
+                >>> from pysat.formula import WCNFPlus
+                >>> cnf = WCNFPlus(from_file='some-file.cnf')
                 >>> print(cnf.to_dimacs())
                 c Example
                 p wcnf+ 7 4 10

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -443,7 +443,8 @@ class CNF(object):
         """
             State reproducible string representaion of object.
         """
-        return f"CNF(from_clauses={self.clauses})"
+        s = self.to_dimacs().replace('\n', '\\n')
+        return f"CNF(from_string=\"{s}\")"
 
     def from_file(self, fname, comment_lead=['c'], compressed_with='use_ext'):
         """
@@ -745,6 +746,39 @@ class CNF(object):
 
         for cl in self.clauses:
             print(' '.join(str(l) for l in cl), '0', file=file_pointer)
+
+    def to_dimacs(self):
+        """
+            Return the current state of the object in DIMACS format.
+
+            For example, if 'some-file.cnf' contains:
+
+            ::
+
+                c Example file
+                p cnf 3 2
+                -1 2 0
+                -2 3 0
+
+            Then you can obtain the DIMACS with:
+
+            .. code-block:: python
+
+                >>> from pysat.formula import CNF
+                >>> cnf = CNF(from_file='some-file.cnf')
+                >>> print(cnf.to_dimacs())
+                c Example: Two cardinality constraints followed by a clause
+                p cnf 3 3
+                -1 2 0
+                -2 3 0
+                -3 0
+
+        """
+        header_lines = [f"p cnf {self.nv} {len(self.clauses)}"]
+        comment_lines = [f"{comment}" for comment in self.comments]
+        clause_lines = [" ".join(map(str,clause)) + " 0" for clause in self.clauses]
+        lines = "\n".join(comment_lines + header_lines + clause_lines) + "\n"
+        return lines
 
     def to_alien(self, file_pointer, format='opb', comments=None):
         """


### PR DESCRIPTION
I've added `__repr__` to all formula classes. Methods of all four CNF classes are based on ``to_dimacs``.

On the other hand, should there be an example and explanation of all the DIMACS formats in the class docstring? Currently, there are only `cnf+` and `wcnf+` examples and explanations, hence my confusion about all the weight stuff with `wcnf` with hard and soft clauses.