### PR TITLE
Add possibility to exclude MIT license incompatible solvers

### DIFF
--- a/installed_solvers.cfg
+++ b/installed_solvers.cfg
@@ -1,0 +1,2 @@
+[pysat_version]
+no_mit_incompatible = False


### PR DESCRIPTION
Lingeling's license is quite restrictive and is thus not compatible with the MIT license. This commit introduces a method to exclude it from the installation. Setting no_mit_incompatible to False ensures that all solvers are installed (same behavior as before).