### PR TITLE
Change patching method for Windows

### DIFF
--- a/solvers/prepare.py
+++ b/solvers/prepare.py
@@ -816,7 +816,7 @@ def patch_solver(solver):
     if platform.system() != 'Windows':
         cmd = 'cd solvers/{0} && patch -p2 < ../patches/{0}.patch'.format(solver)
     else:
-        cmd = 'wsl patch -p0 < solvers/patches/{0}.patch'.format(solver)
+        cmd = 'cd solvers/{0} && git apply --ignore-whitespace --whitespace=warn -p2 < ../patches/{0}.patch'.format(solver)
 
     os.system(cmd)
 


### PR DESCRIPTION
Using git apply is probably more lightweight than assuming a Linux subsystem. It is necessary to use --ignore-whitespace, as different line endings are used in one solver than in the corresponding patch file.