### PR TITLE
Protect True and False Atom from .cleanup

### DIFF
--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -831,7 +831,7 @@ class Formula(object):
             # hence, we need to make sure we don't duplicate formulas
 
             # getting the key to associate the formula with
-            key = Formula._get_key(cls, args, kwargs)
+            key = Formula._get_key(args, kwargs)
 
             if key not in Formula._instances[Formula._context]:
                 # this key is yet unknown; creating a new formula object
@@ -849,7 +849,8 @@ class Formula(object):
 
         raise FormulaError('Formula class does not allow deep copying')
 
-    def _get_key(cls, *args, **kwargs):
+    @staticmethod
+    def _get_key(*args, **kwargs):
         """
             The method is used to extract and return a list of attributes to
             serve as a key associated with the formula requested by a user.

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -586,6 +586,7 @@ class Formula(object):
         Formula._context = context
 
         # updating references to True and False constants in the new context
+        global PYSAT_FALSE, PYSAT_TRUE
         PYSAT_FALSE, PYSAT_TRUE = Atom(False), Atom(True)
 
     @staticmethod


### PR DESCRIPTION
When the `cleanup` method is used on any context the default Atom for True and False are cleaned too.

```
from pysat.formula import Formula, PYSAT_FALSE, PYSAT_TRUE
print(PYSAT_FALSE, PYSAT_TRUE)
>>>F T

Formula.cleanup()
print(PYSAT_FALSE, PYSAT_TRUE)
>>>None None
```

In particulars this mess up the results of simplified:
```
from pysat.formula import Atom, Or, Neg, Formula
print(Or(Atom(1), Neg(Atom(1))).simplified())
>>>T

Formula.cleanup()
print(Or(Atom(1), Neg(Atom(1))).simplified())
>>>None
```

I propose a fix to explicitly exclude PYSAT_FALSE and PYSAT_TRUE from cleanup and to register the same object again in the new context.