### PR TITLE
Fix Neg clausify

### DIFF
--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -1519,6 +1519,7 @@ class And(Formula):
 
         self.name = None
         self.clauses = []
+        self._clauses_tseitin = []
         self.subformulas = []
 
     def _iter(self, outermost=False):
@@ -1531,8 +1532,10 @@ class And(Formula):
             for cl in sub._iter():
                 yield cl
 
-        for cl in self.clauses:
-            yield cl
+        if outermost:
+            yield from self.clauses
+        else:
+            yield from self._clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """
@@ -1614,15 +1617,16 @@ class And(Formula):
 
         # introducing a new name for this formula if required
         if name_required and not self.name:
+            self._clauses_tseitin = [clause.copy() for clause in self.clauses]
             self.name = Formula._vpool[Formula._context].id(self)
 
             cl = [self.name]  # final clause (converse implication)
-            for i in range(len(self.clauses)):
-                cl.append(-self.clauses[i][0])      # updating final clause
-                self.clauses[i].append(-self.name)  # updating direct implication
+            for i in range(len(self._clauses_tseitin)):
+                cl.append(-self._clauses_tseitin[i][0])      # updating final clause
+                self._clauses_tseitin[i].append(-self.name)  # updating direct implication
 
             # adding final clause
-            self.clauses.append(cl)
+            self._clauses_tseitin.append(cl)
 
     def __repr__(self):
         """

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -1912,6 +1912,7 @@ class Neg(Formula):
 
         self.name = None
         self.clauses = []
+        self._clauses_tseitin = []
         self.subformula = None
 
     def _iter(self, outermost=False):
@@ -1922,8 +1923,10 @@ class Neg(Formula):
         for cl in self.subformula._iter():
             yield cl
 
-        for cl in self.clauses:
-            yield cl
+        if outermost:
+            yield from self.clauses
+        else:
+            yield from self._clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """
@@ -1984,7 +1987,6 @@ class Neg(Formula):
         # introducing a new name for this formula if required
         if name_required and not self.name:
             self.name = self.clauses[0][0]
-            self.clauses = []
 
             Formula._vpool[Formula._context].obj2id[self] = self.name
             Formula._vpool[Formula._context].id2obj[self.name] = self

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -790,6 +790,7 @@ class Formula(object):
 
         self.name = None
         self.clauses = []
+        self._clauses_tseitin = []
 
     @classmethod
     def __new__(cls, *args, **kwargs):
@@ -1151,7 +1152,7 @@ class Formula(object):
         self.clausify()
 
         # then recursively iterate through the clauses
-        for cl in self._iter():
+        for cl in self._iter(outermost=True):
             yield cl
 
     def clausify(self):
@@ -1362,7 +1363,7 @@ class Atom(Formula):
         self.clauses = []
         self.object = None
 
-    def _iter(self):
+    def _iter(self, outermost=False):
         """
             Internal iterator over the clauses. Does nothing as there are no
             clauses to iterate through.
@@ -1520,7 +1521,7 @@ class And(Formula):
         self.clauses = []
         self.subformulas = []
 
-    def _iter(self):
+    def _iter(self, outermost=False):
         """
             Internal iterator over the clauses. First, iterates through the
             clauses of the subformulas followed by the formula's own clauses.
@@ -1731,7 +1732,7 @@ class Or(Formula):
         self.clauses = []
         self.subformulas = []
 
-    def _iter(self):
+    def _iter(self, outermost=False):
         """
             Internal iterator over the clauses. First, iterates through the
             clauses of the subformulas followed by the formula's own clauses.
@@ -1905,7 +1906,7 @@ class Neg(Formula):
         self.clauses = []
         self.subformula = None
 
-    def _iter(self):
+    def _iter(self, outermost=False):
         """
             Recursive iterator through the clauses.
         """
@@ -2060,7 +2061,7 @@ class Implies(Formula):
         self.clauses = []
         self.left = self.right = None
 
-    def _iter(self):
+    def _iter(self, outermost=False):
         """
             Clause iterator. Recursively iterates through the clauses of
             ``left`` and ``right`` subformulas followed by own clause
@@ -2261,7 +2262,7 @@ class Equals(Formula):
         self.clauses = []
         self.subformulas = []
 
-    def _iter(self):
+    def _iter(self, outermost=False):
         """
             Internal iterator over the clauses. First, iterates through the
             clauses of the subformulas followed by the formula's own clauses.
@@ -2496,7 +2497,7 @@ class XOr(Formula):
         self.clauses = []
         self.subformulas = []
 
-    def _iter(self):
+    def _iter(self, outermost=False):
         """
             Internal iterator over the clauses. First, iterates through the
             clauses of the subformulas followed by the formula's own clauses.
@@ -2740,7 +2741,7 @@ class ITE(Formula):
         self.clauses = []
         self.cond = self.cons1 = self.cons2 = None
 
-    def _iter(self):
+    def _iter(self, outermost=False):
         """
             Internal iterator over the clauses. First, iterates through the
             clauses of the subformulas followed by the formula's own clauses.
@@ -3583,7 +3584,7 @@ class CNF(Formula, object):
             self.enclits = enclits
             self.nv = self.name
 
-    def _iter(self):
+    def _iter(self, outermost=False):
         """
             This is a copy of :meth:`__iter__`, to be consistent with
             :class:`Formula`.

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -2069,6 +2069,7 @@ class Implies(Formula):
 
         self.name = None
         self.clauses = []
+        self._clauses_tseitin = []
         self.left = self.right = None
 
     def _iter(self, outermost=False):
@@ -2082,8 +2083,10 @@ class Implies(Formula):
             for cl in sub._iter():
                 yield cl
 
-        for cl in self.clauses:
-            yield cl
+        if outermost:
+            yield from self.clauses
+        else:
+            yield from self._clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """
@@ -2150,14 +2153,15 @@ class Implies(Formula):
 
         # introducing a new name for this formula if required
         if name_required and not self.name:
+            self._clauses_tseitin = [clause.copy() for clause in self.clauses]
             self.name = Formula._vpool[Formula._context].id(self)
 
             # direct implication
-            self.clauses[0].append(-self.name)
+            self._clauses_tseitin[0].append(-self.name)
 
             # clauses representing converse implication
-            for i in range(len(self.clauses[0]) - 1):
-                self.clauses.append([self.name, -self.clauses[0][i]])
+            for i in range(len(self._clauses_tseitin[0]) - 1):
+                self._clauses_tseitin.append([self.name, -self._clauses_tseitin[0][i]])
 
     def __repr__(self):
         """

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -1179,8 +1179,7 @@ class Formula(object):
                 [[3, 4]]  # 4 corresponds to z while 3 represents the equality x @ y
         """
 
-        if not self.clauses and not self.name:
-            self._clausify(name_required=False)
+        self._clausify(name_required=False)
 
     def simplified(self, assumptions=[]):
         """
@@ -1385,7 +1384,7 @@ class Atom(Formula):
         """
 
         # true and false constants shouldn't be encoded
-        if self.object not in (False, True):
+        if not self.name and self.object not in (False, True):
             self.name = Formula._vpool[Formula._context].id(self)
             self.clauses = [[self.name]]
 
@@ -1612,6 +1611,7 @@ class And(Formula):
             :param name_required: bool
         """
 
+        save_clauses = bool(self.clauses)
         if not self.clauses:
             # first, recursively encoding subformulas
             for sub in self.subformulas:
@@ -1622,7 +1622,11 @@ class And(Formula):
 
         # introducing a new name for this formula if required
         if name_required and not self.name:
-            self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+            if save_clauses:
+                self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+            else:
+                self._clauses_tseitin = self.clauses
+                self.clauses = []
             self.name = Formula._vpool[Formula._context].id(self)
 
             cl = [self.name]  # final clause (converse implication)
@@ -1827,6 +1831,7 @@ class Or(Formula):
             :param name_required: bool
         """
 
+        save_clauses = bool(self.clauses)
         if not self.clauses:
             # first, recursively encoding subformulas
             self.clauses.append([])  # empty clause, to be filled out
@@ -1838,7 +1843,11 @@ class Or(Formula):
 
         # introducing a new name for this formula if required
         if name_required and not self.name:
-            self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+            if save_clauses:
+                self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+            else:
+                self._clauses_tseitin = self.clauses
+                self.clauses = []
             self.name = Formula._vpool[Formula._context].id(self)
 
             # direct implication
@@ -2150,6 +2159,7 @@ class Implies(Formula):
             :param name_required: bool
         """
 
+        save_clauses = bool(self.clauses)
         if not self.clauses:
             # first, recursively encoding subformula
             self.left._clausify(name_required=True)
@@ -2158,7 +2168,11 @@ class Implies(Formula):
 
         # introducing a new name for this formula if required
         if name_required and not self.name:
-            self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+            if save_clauses:
+                self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+            else:
+                self._clauses_tseitin = self.clauses
+                self.clauses = []
             self.name = Formula._vpool[Formula._context].id(self)
 
             # direct implication
@@ -2385,6 +2399,7 @@ class Equals(Formula):
             :param name_required: bool
         """
 
+        save_clauses = bool(self.clauses)
         if not self.clauses:
             # first, recursively encoding subformulas
             for sub in self.subformulas:
@@ -2397,7 +2412,11 @@ class Equals(Formula):
 
         # introducing a new name for this formula if required
         if name_required and not self.name:
-            self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+            if save_clauses:
+                self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+            else:
+                self._clauses_tseitin = self.clauses
+                self.clauses = []
             self.name = Formula._vpool[Formula._context].id(self)
 
             # direct implication (just adding the selector)
@@ -2609,6 +2628,7 @@ class XOr(Formula):
             :param name_required: bool
         """
 
+        save_clauses = bool(self.clauses)
         if not self.clauses:
             # first, recursively encoding subformulas
             inputs = []
@@ -2652,7 +2672,11 @@ class XOr(Formula):
 
         # introducing a new name for this formula if required
         if name_required and not self.name:
-            self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+            if save_clauses:
+                self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+            else:
+                self._clauses_tseitin = self.clauses
+                self.clauses = []
             n1, n2 = self._clauses_tseitin[-1]
             if len(self.subformulas) > 2:
                 # reconstructing the final subterm
@@ -2852,6 +2876,7 @@ class ITE(Formula):
             :param name_required: bool
         """
 
+        save_clauses = bool(self.clauses)
         if not self.clauses:
             # first, recursively encoding subformula
             self.cond._clausify(name_required=True)
@@ -2862,7 +2887,11 @@ class ITE(Formula):
 
         # introducing a new name for this formula if required
         if name_required and not self.name:
-            self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+            if save_clauses:
+                self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+            else:
+                self._clauses_tseitin = self.clauses
+                self.clauses = []
             self.name = Formula._vpool[Formula._context].id(self)
 
             # direct implication

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -1734,6 +1734,7 @@ class Or(Formula):
 
         self.name = None
         self.clauses = []
+        self._clauses_tseitin = []
         self.subformulas = []
 
     def _iter(self, outermost=False):
@@ -1746,8 +1747,10 @@ class Or(Formula):
             for cl in sub._iter():
                 yield cl
 
-        for cl in self.clauses:
-            yield cl
+        if outermost:
+            yield from self.clauses
+        else:
+            yield from self._clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """
@@ -1830,14 +1833,15 @@ class Or(Formula):
 
         # introducing a new name for this formula if required
         if name_required and not self.name:
+            self._clauses_tseitin = [clause.copy() for clause in self.clauses]
             self.name = Formula._vpool[Formula._context].id(self)
 
             # direct implication
-            self.clauses[0].append(-self.name)
+            self._clauses_tseitin[0].append(-self.name)
 
             # clauses representing converse implication
-            for i in range(len(self.clauses[0]) - 1):
-                self.clauses.append([self.name, -self.clauses[0][i]])
+            for i in range(len(self._clauses_tseitin[0]) - 1):
+                self._clauses_tseitin.append([self.name, -self._clauses_tseitin[0][i]])
 
     def __repr__(self):
         """

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -3195,6 +3195,7 @@ class CNF(Formula, object):
         cnf = CNF()
         cnf.nv = self.nv
         cnf.clauses = copy.deepcopy(self.clauses)
+        cnf._clauses_tseitin = copy.deepcopy(self._clauses_tseitin)
         cnf.comments = copy.deepcopy(self.comments)
 
         return cnf
@@ -3605,7 +3606,7 @@ class CNF(Formula, object):
                 # just in case, marking all ids below self.name as occupied
                 Formula._vpool[Formula._context].occupy(1, self.name)
 
-            self.clauses = clauses
+            self._clauses_tseitin = clauses
             self.auxvars = auxvars
             self.enclits = enclits
             self.nv = self.name
@@ -3616,8 +3617,10 @@ class CNF(Formula, object):
             :class:`Formula`.
         """
 
-        for cl in self.clauses:
-            yield cl
+        if outermost:
+            yield from self.clauses
+        else:
+            yield from self._clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -2761,6 +2761,7 @@ class ITE(Formula):
 
         self.name = None
         self.clauses = []
+        self._clauses_tseitin = []
         self.cond = self.cons1 = self.cons2 = None
 
     def _iter(self, outermost=False):
@@ -2773,8 +2774,10 @@ class ITE(Formula):
             for cl in sub._iter():
                 yield cl
 
-        for cl in self.clauses:
-            yield cl
+        if outermost:
+            yield from self.clauses
+        else:
+            yield from self._clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """
@@ -2854,16 +2857,17 @@ class ITE(Formula):
 
         # introducing a new name for this formula if required
         if name_required and not self.name:
+            self._clauses_tseitin = [clause.copy() for clause in self.clauses]
             self.name = Formula._vpool[Formula._context].id(self)
 
             # direct implication
-            self.clauses[0].append(-self.name)
-            self.clauses[1].append(-self.name)
+            self._clauses_tseitin[0].append(-self.name)
+            self._clauses_tseitin[1].append(-self.name)
 
             # converse implication
-            self.clauses.append([self.name, -self.cond.name,  -self.cons1.name])
-            self.clauses.append([self.name, +self.cond.name,  -self.cons2.name])
-            self.clauses.append([self.name, -self.cons1.name, -self.cons2.name])
+            self._clauses_tseitin.append([self.name, -self.cond.name,  -self.cons1.name])
+            self._clauses_tseitin.append([self.name, +self.cond.name,  -self.cons2.name])
+            self._clauses_tseitin.append([self.name, -self.cons1.name, -self.cons2.name])
 
     def __repr__(self):
         """

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -1350,6 +1350,7 @@ class Atom(Formula):
             assert self.object > 0, 'Variables should be represented as positive integers'
 
             self.name = self.object  # using the integer id as the name
+            self.clauses = [[self.name]]
             Formula._vpool[Formula._context].obj2id[self] = self.name
             Formula._vpool[Formula._context].id2obj[self.name] = self
             Formula._vpool[Formula._context].occupy(1, self.name)
@@ -1361,6 +1362,7 @@ class Atom(Formula):
 
         self.name = None
         self.clauses = []
+        self._clauses_tseitin = []  # always empty
         self.object = None
 
     def _iter(self, outermost=False):
@@ -1369,8 +1371,10 @@ class Atom(Formula):
             clauses to iterate through.
         """
 
-        for cl in self.clauses:
-            yield cl
+        if outermost:
+            yield from self.clauses
+        else:
+            yield from self._clauses_tseitin
 
     def _clausify(self, name_required=True):
         """
@@ -1383,6 +1387,7 @@ class Atom(Formula):
         # true and false constants shouldn't be encoded
         if self.object not in (False, True):
             self.name = Formula._vpool[Formula._context].id(self)
+            self.clauses = [[self.name]]
 
     def simplified(self, assumptions=[]):
         """

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -2274,6 +2274,7 @@ class Equals(Formula):
 
         self.name = None
         self.clauses = []
+        self._clauses_tseitin = []
         self.subformulas = []
 
     def _iter(self, outermost=False):
@@ -2286,8 +2287,10 @@ class Equals(Formula):
             for cl in sub._iter():
                 yield cl
 
-        for cl in self.clauses:
-            yield cl
+        if outermost:
+            yield from self.clauses
+        else:
+            yield from self._clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """
@@ -2389,15 +2392,16 @@ class Equals(Formula):
 
         # introducing a new name for this formula if required
         if name_required and not self.name:
+            self._clauses_tseitin = [clause.copy() for clause in self.clauses]
             self.name = Formula._vpool[Formula._context].id(self)
 
             # direct implication (just adding the selector)
-            for cl in self.clauses:
+            for cl in self._clauses_tseitin:
                 cl.append(-self.name)
 
             # clauses representing converse implication
-            self.clauses.append([self.name] + [-s.name for s in self.subformulas])
-            self.clauses.append([self.name] + [+s.name for s in self.subformulas])
+            self._clauses_tseitin.append([self.name] + [-s.name for s in self.subformulas])
+            self._clauses_tseitin.append([self.name] + [+s.name for s in self.subformulas])
 
     def __repr__(self):
         """

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -790,7 +790,7 @@ class Formula(object):
 
         self.name = None
         self.clauses = []
-        self._clauses_tseitin = []
+        self.clauses_tseitin = []
 
     @classmethod
     def __new__(cls, *args, **kwargs):
@@ -1361,7 +1361,7 @@ class Atom(Formula):
 
         self.name = None
         self.clauses = []
-        self._clauses_tseitin = []  # always empty
+        self.clauses_tseitin = []  # always empty
         self.object = None
 
     def _iter(self, outermost=False):
@@ -1373,7 +1373,7 @@ class Atom(Formula):
         if outermost:
             yield from self.clauses
         else:
-            yield from self._clauses_tseitin
+            yield from self.clauses_tseitin
 
     def _clausify(self, name_required=True):
         """
@@ -1523,7 +1523,7 @@ class And(Formula):
 
         self.name = None
         self.clauses = []
-        self._clauses_tseitin = []
+        self.clauses_tseitin = []
         self.subformulas = []
 
     def _iter(self, outermost=False):
@@ -1539,7 +1539,7 @@ class And(Formula):
         if outermost:
             yield from self.clauses
         else:
-            yield from self._clauses_tseitin
+            yield from self.clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """
@@ -1623,19 +1623,19 @@ class And(Formula):
         # introducing a new name for this formula if required
         if name_required and not self.name:
             if save_clauses:
-                self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+                self.clauses_tseitin = [clause.copy() for clause in self.clauses]
             else:
-                self._clauses_tseitin = self.clauses
+                self.clauses_tseitin = self.clauses
                 self.clauses = []
             self.name = Formula._vpool[Formula._context].id(self)
 
             cl = [self.name]  # final clause (converse implication)
-            for i in range(len(self._clauses_tseitin)):
-                cl.append(-self._clauses_tseitin[i][0])      # updating final clause
-                self._clauses_tseitin[i].append(-self.name)  # updating direct implication
+            for i in range(len(self.clauses_tseitin)):
+                cl.append(-self.clauses_tseitin[i][0])      # updating final clause
+                self.clauses_tseitin[i].append(-self.name)  # updating direct implication
 
             # adding final clause
-            self._clauses_tseitin.append(cl)
+            self.clauses_tseitin.append(cl)
 
     def __repr__(self):
         """
@@ -1743,7 +1743,7 @@ class Or(Formula):
 
         self.name = None
         self.clauses = []
-        self._clauses_tseitin = []
+        self.clauses_tseitin = []
         self.subformulas = []
 
     def _iter(self, outermost=False):
@@ -1759,7 +1759,7 @@ class Or(Formula):
         if outermost:
             yield from self.clauses
         else:
-            yield from self._clauses_tseitin
+            yield from self.clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """
@@ -1844,18 +1844,18 @@ class Or(Formula):
         # introducing a new name for this formula if required
         if name_required and not self.name:
             if save_clauses:
-                self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+                self.clauses_tseitin = [clause.copy() for clause in self.clauses]
             else:
-                self._clauses_tseitin = self.clauses
+                self.clauses_tseitin = self.clauses
                 self.clauses = []
             self.name = Formula._vpool[Formula._context].id(self)
 
             # direct implication
-            self._clauses_tseitin[0].append(-self.name)
+            self.clauses_tseitin[0].append(-self.name)
 
             # clauses representing converse implication
-            for i in range(len(self._clauses_tseitin[0]) - 1):
-                self._clauses_tseitin.append([self.name, -self._clauses_tseitin[0][i]])
+            for i in range(len(self.clauses_tseitin[0]) - 1):
+                self.clauses_tseitin.append([self.name, -self.clauses_tseitin[0][i]])
 
     def __repr__(self):
         """
@@ -1926,7 +1926,7 @@ class Neg(Formula):
 
         self.name = None
         self.clauses = []
-        self._clauses_tseitin = []
+        self.clauses_tseitin = []
         self.subformula = None
 
     def _iter(self, outermost=False):
@@ -1940,7 +1940,7 @@ class Neg(Formula):
         if outermost:
             yield from self.clauses
         else:
-            yield from self._clauses_tseitin
+            yield from self.clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """
@@ -2083,7 +2083,7 @@ class Implies(Formula):
 
         self.name = None
         self.clauses = []
-        self._clauses_tseitin = []
+        self.clauses_tseitin = []
         self.left = self.right = None
 
     def _iter(self, outermost=False):
@@ -2100,7 +2100,7 @@ class Implies(Formula):
         if outermost:
             yield from self.clauses
         else:
-            yield from self._clauses_tseitin
+            yield from self.clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """
@@ -2169,18 +2169,18 @@ class Implies(Formula):
         # introducing a new name for this formula if required
         if name_required and not self.name:
             if save_clauses:
-                self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+                self.clauses_tseitin = [clause.copy() for clause in self.clauses]
             else:
-                self._clauses_tseitin = self.clauses
+                self.clauses_tseitin = self.clauses
                 self.clauses = []
             self.name = Formula._vpool[Formula._context].id(self)
 
             # direct implication
-            self._clauses_tseitin[0].append(-self.name)
+            self.clauses_tseitin[0].append(-self.name)
 
             # clauses representing converse implication
-            for i in range(len(self._clauses_tseitin[0]) - 1):
-                self._clauses_tseitin.append([self.name, -self._clauses_tseitin[0][i]])
+            for i in range(len(self.clauses_tseitin[0]) - 1):
+                self.clauses_tseitin.append([self.name, -self.clauses_tseitin[0][i]])
 
     def __repr__(self):
         """
@@ -2293,7 +2293,7 @@ class Equals(Formula):
 
         self.name = None
         self.clauses = []
-        self._clauses_tseitin = []
+        self.clauses_tseitin = []
         self.subformulas = []
 
     def _iter(self, outermost=False):
@@ -2309,7 +2309,7 @@ class Equals(Formula):
         if outermost:
             yield from self.clauses
         else:
-            yield from self._clauses_tseitin
+            yield from self.clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """
@@ -2413,19 +2413,19 @@ class Equals(Formula):
         # introducing a new name for this formula if required
         if name_required and not self.name:
             if save_clauses:
-                self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+                self.clauses_tseitin = [clause.copy() for clause in self.clauses]
             else:
-                self._clauses_tseitin = self.clauses
+                self.clauses_tseitin = self.clauses
                 self.clauses = []
             self.name = Formula._vpool[Formula._context].id(self)
 
             # direct implication (just adding the selector)
-            for cl in self._clauses_tseitin:
+            for cl in self.clauses_tseitin:
                 cl.append(-self.name)
 
             # clauses representing converse implication
-            self._clauses_tseitin.append([self.name] + [-s.name for s in self.subformulas])
-            self._clauses_tseitin.append([self.name] + [+s.name for s in self.subformulas])
+            self.clauses_tseitin.append([self.name] + [-s.name for s in self.subformulas])
+            self.clauses_tseitin.append([self.name] + [+s.name for s in self.subformulas])
 
     def __repr__(self):
         """
@@ -2537,7 +2537,7 @@ class XOr(Formula):
 
         self.name = None
         self.clauses = []
-        self._clauses_tseitin = []
+        self.clauses_tseitin = []
         self.subformulas = []
 
     def _iter(self, outermost=False):
@@ -2553,7 +2553,7 @@ class XOr(Formula):
         if outermost:
             yield from self.clauses
         else:
-            yield from self._clauses_tseitin
+            yield from self.clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """
@@ -2651,7 +2651,7 @@ class XOr(Formula):
                     ao._clausify(name_required=True)
 
                     # collecting all the corresponding clauses
-                    self.clauses += ao._clauses_tseitin
+                    self.clauses += ao.clauses_tseitin
 
                     inputs.append(ao.name)
 
@@ -2673,11 +2673,11 @@ class XOr(Formula):
         # introducing a new name for this formula if required
         if name_required and not self.name:
             if save_clauses:
-                self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+                self.clauses_tseitin = [clause.copy() for clause in self.clauses]
             else:
-                self._clauses_tseitin = self.clauses
+                self.clauses_tseitin = self.clauses
                 self.clauses = []
-            n1, n2 = self._clauses_tseitin[-1]
+            n1, n2 = self.clauses_tseitin[-1]
             if len(self.subformulas) > 2:
                 # reconstructing the final subterm
                 f1 = Formula._vpool[Formula._context].obj(n1)
@@ -2691,17 +2691,17 @@ class XOr(Formula):
                 final = None
 
             # direct implication (just adding the selector)
-            self._clauses_tseitin[-2].append(-self.name)
-            self._clauses_tseitin[-1].append(-self.name)
+            self.clauses_tseitin[-2].append(-self.name)
+            self.clauses_tseitin[-1].append(-self.name)
 
             # clauses representing converse implication
-            self._clauses_tseitin.append([self.name, -n1, +n2])
-            self._clauses_tseitin.append([self.name, +n1, -n2])
+            self.clauses_tseitin.append([self.name, -n1, +n2])
+            self.clauses_tseitin.append([self.name, +n1, -n2])
 
             if final:
                 # sharing converse implication with final subterm (if any)
-                final._clauses_tseitin.append(self._clauses_tseitin[-2])
-                final._clauses_tseitin.append(self._clauses_tseitin[-1])
+                final.clauses_tseitin.append(self.clauses_tseitin[-2])
+                final.clauses_tseitin.append(self.clauses_tseitin[-1])
 
     def __repr__(self):
         """
@@ -2790,7 +2790,7 @@ class ITE(Formula):
 
         self.name = None
         self.clauses = []
-        self._clauses_tseitin = []
+        self.clauses_tseitin = []
         self.cond = self.cons1 = self.cons2 = None
 
     def _iter(self, outermost=False):
@@ -2806,7 +2806,7 @@ class ITE(Formula):
         if outermost:
             yield from self.clauses
         else:
-            yield from self._clauses_tseitin
+            yield from self.clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """
@@ -2888,20 +2888,20 @@ class ITE(Formula):
         # introducing a new name for this formula if required
         if name_required and not self.name:
             if save_clauses:
-                self._clauses_tseitin = [clause.copy() for clause in self.clauses]
+                self.clauses_tseitin = [clause.copy() for clause in self.clauses]
             else:
-                self._clauses_tseitin = self.clauses
+                self.clauses_tseitin = self.clauses
                 self.clauses = []
             self.name = Formula._vpool[Formula._context].id(self)
 
             # direct implication
-            self._clauses_tseitin[0].append(-self.name)
-            self._clauses_tseitin[1].append(-self.name)
+            self.clauses_tseitin[0].append(-self.name)
+            self.clauses_tseitin[1].append(-self.name)
 
             # converse implication
-            self._clauses_tseitin.append([self.name, -self.cond.name,  -self.cons1.name])
-            self._clauses_tseitin.append([self.name, +self.cond.name,  -self.cons2.name])
-            self._clauses_tseitin.append([self.name, -self.cons1.name, -self.cons2.name])
+            self.clauses_tseitin.append([self.name, -self.cond.name,  -self.cons1.name])
+            self.clauses_tseitin.append([self.name, +self.cond.name,  -self.cons2.name])
+            self.clauses_tseitin.append([self.name, -self.cons1.name, -self.cons2.name])
 
     def __repr__(self):
         """
@@ -3229,7 +3229,7 @@ class CNF(Formula, object):
         cnf = CNF()
         cnf.nv = self.nv
         cnf.clauses = copy.deepcopy(self.clauses)
-        cnf._clauses_tseitin = copy.deepcopy(self._clauses_tseitin)
+        cnf.clauses_tseitin = copy.deepcopy(self.clauses_tseitin)
         cnf.comments = copy.deepcopy(self.comments)
 
         return cnf
@@ -3640,7 +3640,7 @@ class CNF(Formula, object):
                 # just in case, marking all ids below self.name as occupied
                 Formula._vpool[Formula._context].occupy(1, self.name)
 
-            self._clauses_tseitin = clauses
+            self.clauses_tseitin = clauses
             self.auxvars = auxvars
             self.enclits = enclits
             self.nv = self.name
@@ -3654,7 +3654,7 @@ class CNF(Formula, object):
         if outermost:
             yield from self.clauses
         else:
-            yield from self._clauses_tseitin
+            yield from self.clauses_tseitin
 
     def simplified(self, assumptions=[]):
         """

--- a/tests/test_clausification.py
+++ b/tests/test_clausification.py
@@ -1,0 +1,37 @@
+from pysat.formula import Atom, Formula, And, Or, Neg, XOr
+
+
+def compare(a, b):
+    assert tuple(map(tuple, a)) == tuple(map(tuple, b)), f'{a} != {b}'
+
+
+def test_clausification():
+    # Atom outermost
+    compare(list(Atom(1)), [[1]])
+
+    # Neg outermost clauses
+    compare(list(Neg(Atom(1))), [[-1]])
+    compare(list(Neg(And(Atom(1), Atom(2)))), [[1, -4], [2, -4], [4, -1, -2], [-4]])
+
+    # Neg inner clauses
+    compare(list(Or(Neg(And(Atom(1), Atom(2))), Atom(3))),
+            [[1, -4], [2, -4], [4, -1, -2], [-4, 3]])
+    compare(list(Or(Atom(1), Neg(Atom(2)), Neg(Atom(2)))), [[1, -2, -2]])
+
+    # XOr outermost
+    compare(list(XOr(Atom(1), Atom(2))), [[-1, -2], [1, 2]])
+    compare(list(XOr(Atom(1), Atom(2), Atom(3))), [[-2, -3, -5], [2, 3, -5], [5, -2, 3], [5, 2, -3], [-1, -5],
+                                                   [1, 5]])
+
+    # XOr inner
+    compare(list(And(XOr(Atom(1), Atom(2), Atom(3)), Atom(4))), [[-2, -3, -5], [2, 3, -5], [5, -2, 3],
+                                                                 [5, 2, -3], [-1, -5, -6], [1, 5, -6], [6, -1, 5],
+                                                                 [6, 1, -5], [6], [4]])
+
+    # multiple successive inner/outermost clausification
+    f = And(Atom(1), Atom(2))
+    g = And(f, Atom(3))
+    compare(list(f), [[1], [2]])
+    compare(list(g), [[1, -4], [2, -4], [4, -1, -2], [4], [3]])
+    compare(list(f), [[1], [2]])
+    compare(list(g), [[1, -4], [2, -4], [4, -1, -2], [4], [3]])

--- a/tests/test_clausification.py
+++ b/tests/test_clausification.py
@@ -6,32 +6,36 @@ def compare(a, b):
 
 
 def test_clausification():
+    # reset vpool
+    Formula.cleanup()
+
     # Atom outermost
-    compare(list(Atom(1)), [[1]])
+    compare(list(Atom('1')), [[1]])
 
     # Neg outermost clauses
-    compare(list(Neg(Atom(1))), [[-1]])
-    compare(list(Neg(And(Atom(1), Atom(2)))), [[1, -4], [2, -4], [4, -1, -2], [-4]])
+    compare(list(Neg(Atom('1'))), [[-1]])
+
+    compare(list(Neg(And(Atom('1'), Atom('2')))), [[1, -3], [2, -3], [3, -1, -2], [-3]])
 
     # Neg inner clauses
-    compare(list(Or(Neg(And(Atom(1), Atom(2))), Atom(3))),
-            [[1, -4], [2, -4], [4, -1, -2], [-4, 3]])
-    compare(list(Or(Atom(1), Neg(Atom(2)), Neg(Atom(2)))), [[1, -2, -2]])
+    compare(list(Or(Neg(And(Atom('1'), Atom('2'))), Atom('3'))),
+            [[1, -3], [2, -3], [3, -1, -2], [-3, 4]])
+    compare(list(Or(Atom('1'), Neg(Atom('2')), Neg(Atom('2')))), [[1, -2, -2]])
 
     # XOr outermost
-    compare(list(XOr(Atom(1), Atom(2))), [[-1, -2], [1, 2]])
-    compare(list(XOr(Atom(1), Atom(2), Atom(3))), [[-2, -3, -5], [2, 3, -5], [5, -2, 3], [5, 2, -3], [-1, -5],
-                                                   [1, 5]])
+    compare(list(XOr(Atom('1'), Atom('2'))), [[-1, -2], [1, 2]])
+    compare(list(XOr(Atom('1'), Atom('2'), Atom('3'))), [[-2, -4, -5], [2, 4, -5], [5, -2, 4], [5, 2, -4],
+                                                         [-1, -5], [1, 5]])
 
     # XOr inner
-    compare(list(And(XOr(Atom(1), Atom(2), Atom(3)), Atom(4))), [[-2, -3, -5], [2, 3, -5], [5, -2, 3],
-                                                                 [5, 2, -3], [-1, -5, -6], [1, 5, -6], [6, -1, 5],
-                                                                 [6, 1, -5], [6], [4]])
+    compare(list(And(XOr(Atom('1'), Atom('2'), Atom('3')), Atom('4'))), [[-2, -4, -5], [2, 4, -5],
+                                                                         [5, -2, 4], [5, 2, -4], [-1, -5, -6],
+                                                                         [1, 5, -6], [6, -1, 5], [6, 1, -5], [6], [7]])
 
     # multiple successive inner/outermost clausification
-    f = And(Atom(1), Atom(2))
-    g = And(f, Atom(3))
+    f = And(Atom('1'), Atom('2'))
+    g = And(f, Atom('3'))
     compare(list(f), [[1], [2]])
-    compare(list(g), [[1, -4], [2, -4], [4, -1, -2], [4], [3]])
+    compare(list(g), [[1, -3], [2, -3], [3, -1, -2], [3], [4]])
     compare(list(f), [[1], [2]])
-    compare(list(g), [[1, -4], [2, -4], [4, -1, -2], [4], [3]])
+    compare(list(g), [[1, -3], [2, -3], [3, -1, -2], [3], [4]])


### PR DESCRIPTION
Neg clausify is broken, it returns itself as a clause but I don't think it should ever do that.
An example:
``` 
from pysat.formula import Atom, And, Or, Neg
f = Or(Atom(1), Neg(Atom(2)), Neg(Atom(2)))
print(list(f))
>>> [[-2], [-2], [1, -2, -2]]
```
This assume that all models contain -2, but [1, 2] is a valid model. (The correct clause should be only [1, -2, -2], without the [-2]).

I propose a fix where Neg clauses is always empty. An extra variable `clausified`  is used to avoid multiple clausify of the subformula.