### PR TITLE
Fix cleanup and CNF vpool updating

### DIFF
--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -3465,6 +3465,7 @@ class CNF(Formula, object):
         """
 
         self.nv = max([abs(l) for l in clause] + [self.nv])
+        Formula._vpool[Formula._context].occupy(1, self.nv)
         self.clauses.append(list(clause))
 
     def extend(self, clauses):

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -2988,10 +2988,6 @@ class CNF(Formula, object):
         elif from_aiger:
             self.from_aiger(from_aiger)
 
-        # in case we use this CNF as a subformula in the future,
-        # let's put the number of used variables in Formula's IDPool
-        Formula._vpool[Formula._context].occupy(1, self.nv)
-
     def __new__(cls, *args, **kwargs):
         """
             While :class:`CNF` inherits from :class:`Formula` (and so do its
@@ -3010,6 +3006,16 @@ class CNF(Formula, object):
 
         s = self.to_dimacs().replace('\n', '\\n')
         return f'CNF(from_string=\'{s}\')'
+
+    def _compute_nv(self):
+        """
+            Search and store the highest variable.
+        """
+        self.nv = max(map(abs, itertools.chain(*self.clauses)))
+
+        # in case we use this CNF as a subformula in the future,
+        # let's put the number of used variables in Formula's IDPool
+        Formula._vpool[Formula._context].occupy(1, self.nv)
 
     def from_file(self, fname, comment_lead=['c'], compressed_with='use_ext'):
         """
@@ -3085,7 +3091,7 @@ class CNF(Formula, object):
                 elif not line.startswith('p cnf '):
                     self.comments.append(line)
 
-        self.nv = max(map(lambda cl: max(map(abs, cl)), itertools.chain.from_iterable([[[self.nv]], self.clauses])))
+        self._compute_nv()
 
     def from_string(self, string, comment_lead=['c']):
         """
@@ -3147,8 +3153,7 @@ class CNF(Formula, object):
 
         self.clauses = clauses if by_ref else copy.deepcopy(clauses)
 
-        for cl in self.clauses:
-            self.nv = max([abs(l) for l in cl] + [self.nv])
+        self._compute_nv()
 
     def from_aiger(self, aig, vpool=None):
         """
@@ -3210,7 +3215,7 @@ class CNF(Formula, object):
 
         self.clauses = [list(cls) for cls in aig_cnf.clauses]
         self.comments = ['c ' + c.strip() for c in aig_cnf.comments]
-        self.nv = max(map(abs, itertools.chain(*self.clauses)))
+        self._compute_nv()
 
         # saving input and output variables
         self.inps = list(aig_cnf.input2lit.values())

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -651,7 +651,7 @@ class Formula(object):
             to_clean = [context] if context in Formula._instances else []
         else:
             # everything
-            to_clean = list(Formula._instances.keys())
+            to_clean = list(set(Formula._vpool).union(set(Formula._instances)))
 
         # actual cleaning
         for ctx in to_clean:


### PR DESCRIPTION
Hello, I propose a fix to `test_clausification` not passing after #167.

Currently on master vpool are not cleaned correctly after creating a CNF:
```
print(dict(Formula._vpool))
>>> {}

cnf = CNF(from_clauses=[[1, 2, 3]])
print(dict(Formula._vpool))
>>> {'default': IDPool(start_from=1, occupied=[[1, 3]])}

Formula.cleanup()
print(dict(Formula._vpool))
>>> {'default': IDPool(start_from=1, occupied=[[1, 3]])}
```

It is because `Formula.cleanup` only looks at context within `_instances` and not at context in `._vpool`. 
It is possible to have a context in `_vpool` without being in `_instances` (ex: creating a CNF).
It is also possible to have a context in `_instances` without being in `_vpool` (ex: creating Atom(int)).
The bug didn't appear before because `'default'` context was always in `_instances` with Atom(True/False), but the problem still existed for other contexts.

I propose to simply looks in both `_vpool` and `_instances` when cleaning all.

Additional fixes:
* In CNF the logic to update `self.nv` what duplicated (with different variation doing the same thing), I propose to centralize it into `_compute_nv()`.
* `CNF.append` was not updating the _vpool occupy. I fix it. This will add some extra computation (not much) but I don't see a way around it.