### PR TITLE
docs(formula): fix rendering of the `Implies` class in the `pysat.formula` module docstring

### DIFF
--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -192,7 +192,7 @@
     Namely, a user may create complex formulas using variables (atomic
     formulas implemented as objects of class :class:`Atom`), and the following
     logic connectives: :class:`And`, :class:`Or`, :class:`Neg`,
-    class:`Implies`, :class:`Equals`, :class:`XOr`, and :class:`ITE`. (All of
+    :class:`Implies`, :class:`Equals`, :class:`XOr`, and :class:`ITE`. (All of
     these classes inherit from the base class :class:`Formula`.) Arbitrary
     combinations of these logic connectives are allowed. Importantly, the
     module provides seamless integration of :class:`CNF` and various


### PR DESCRIPTION
There's a missing colon in the `pysat.formula` module docstring, causing the `Implies` class to be rendered incorrectly:
![image](https://github.com/pysathq/pysat/assets/22752929/d507c55d-93b6-4c28-a60d-209465b14f50)

This PR fixes this by adding the missing colon.