### PR TITLE
Add simple tests of CNF behaviour (construction, copy)

### DIFF
--- a/tests/test_cnf.py
+++ b/tests/test_cnf.py
@@ -27,7 +27,7 @@ cnf1.append(range(1, 6))  # at least 1
 cnf2 = CardEnc.atmost(lits=range(1, 6), bound=1, encoding=EncType.seqcounter)
 cnf2.append(range(1, 6))  # at least 1
 
-def test_cnfplus():
+def test_cnfplus_solvers():
     # testing cnf1:
     for name in solvers:
         if name not in ('minicard', 'gluecard30', 'gluecard41'):
@@ -59,7 +59,7 @@ def test_cnfplus():
                     pass
             assert i == 5, 'there should be 5 models'
 
-def test_cnf():
+def test_cnf_solvers():
     # testing cnf2
     for name in solvers:
         with Solver(name=name, bootstrap_with=cnf2) as s:

--- a/tests/test_cnf.py
+++ b/tests/test_cnf.py
@@ -27,6 +27,16 @@ cnf1.append(range(1, 6))  # at least 1
 cnf2 = CardEnc.atmost(lits=range(1, 6), bound=1, encoding=EncType.seqcounter)
 cnf2.append(range(1, 6))  # at least 1
 
+def test_cnf():
+    cnf = CNF()
+    cnf_copy = cnf.copy()
+    # TODO: check actual values of the copy for sanity.
+
+def test_cnfplus():
+    cnfplus = CNFPlus()
+    cnfplus_copy = cnfplus.copy()
+    # TODO: check actual values of the copy for sanity.
+
 def test_cnfplus_solvers():
     # testing cnf1:
     for name in solvers:

--- a/tests/test_cnf.py
+++ b/tests/test_cnf.py
@@ -1,3 +1,4 @@
+import pytest
 from pysat.card import *
 from pysat.formula import CNFPlus
 from pysat.solvers import Solver, SolverNames
@@ -27,11 +28,13 @@ cnf1.append(range(1, 6))  # at least 1
 cnf2 = CardEnc.atmost(lits=range(1, 6), bound=1, encoding=EncType.seqcounter)
 cnf2.append(range(1, 6))  # at least 1
 
+@pytest.mark.xfail(reason="CNFs are currently not generally copyable")
 def test_cnf():
     cnf = CNF()
     cnf_copy = cnf.copy()
     # TODO: check actual values of the copy for sanity.
 
+@pytest.mark.xfail(reason="CNFPlus are currently not generally copyable")
 def test_cnfplus():
     cnfplus = CNFPlus()
     cnfplus_copy = cnfplus.copy()


### PR DESCRIPTION
Copying a new empty CNF should not raise an exception.
