### PR TITLE
Fix invalid escape sequence warnings

### DIFF
--- a/pysat/_fileio.py
+++ b/pysat/_fileio.py
@@ -8,7 +8,7 @@
 ##      E-mail: aignatiev@ciencias.ulisboa.pt
 ##
 
-"""
+r"""
     ===============
     List of classes
     ===============

--- a/pysat/card.py
+++ b/pysat/card.py
@@ -8,7 +8,7 @@
 ##      E-mail: aignatiev@ciencias.ulisboa.pt
 ##
 
-"""
+r"""
     ===============
     List of classes
     ===============
@@ -126,7 +126,7 @@ class UnsupportedBound(Exception):
 #
 #==============================================================================
 class EncType(object):
-    """
+    r"""
         This class represents a C-like ``enum`` type for choosing the
         cardinality encoding to use. The values denoting the encodings are:
 
@@ -246,7 +246,7 @@ class CardEnc(object):
     @classmethod
     def atmost(cls, lits, bound=1, top_id=None, vpool=None,
             encoding=EncType.seqcounter):
-        """
+        r"""
             This method can be used for creating a CNF encoding of an AtMostK
             constraint, i.e. of :math:`\\sum_{i=1}^{n}{x_i}\\leq k`. The
             method shares the arguments and the return type with method
@@ -308,7 +308,7 @@ class CardEnc(object):
     @classmethod
     def atleast(cls, lits, bound=1, top_id=None, vpool=None,
             encoding=EncType.seqcounter):
-        """
+        r"""
             This method can be used for creating a CNF encoding of an AtLeastK
             constraint, i.e. of :math:`\\sum_{i=1}^{n}{x_i}\\geq k`. The
             method takes 1 mandatory argument ``lits`` and 3 default arguments
@@ -409,7 +409,7 @@ class CardEnc(object):
     @classmethod
     def equals(cls, lits, bound=1, top_id=None, vpool=None,
             encoding=EncType.seqcounter):
-        """
+        r"""
             This method can be used for creating a CNF encoding of an EqualsK
             constraint, i.e. of :math:`\\sum_{i=1}^{n}{x_i}= k`. The method
             makes consecutive calls of both :meth:`CardEnc.atleast` and

--- a/pysat/engines.py
+++ b/pysat/engines.py
@@ -340,7 +340,7 @@ class LinearConstraint:
 #
 #==============================================================================
 class ParityConstraint:
-    """
+    r"""
         A possible implementation of parity constraints. These are constraints
         of the form :math:`l_1 \\oplus l_2 \\oplus \\ldots \\oplus l_n = b`
         where each :math:`l_i` is a Boolean literal while :math:`b` is a

--- a/pysat/formula.py
+++ b/pysat/formula.py
@@ -8,7 +8,7 @@
 ##      E-mail: aignatiev@ciencias.ulisboa.pt
 ##
 
-"""
+r"""
     ===============
     List of classes
     ===============
@@ -1457,7 +1457,7 @@ Formula.set_context('default')
 #
 #==============================================================================
 class And(Formula):
-    """
+    r"""
         Conjunction. Given a list of operands (subformulas) :math:`f_i`,
         :math:`i \\in \\{1,\\ldots,n\\}, n \\in \\mathbb{N}`, it creates a
         formula :math:`\\bigwedge_{i=1}^{n}{f_i}`. The list of operands *of
@@ -1613,7 +1613,7 @@ class And(Formula):
         return And(*operands, merge=True) if self.merged else And(*operands)
 
     def _clausify(self, name_required=True):
-        """
+        r"""
             Conjuction clausification.
 
             If ``name_required`` is ``False``, the method recursively encodes
@@ -1679,7 +1679,7 @@ class And(Formula):
 #
 #==============================================================================
 class Or(Formula):
-    """
+    r"""
         Disjunction. Given a list of operands (subformulas) :math:`f_i`,
         :math:`i \\in \\{1,\\ldots,n\\}, n \\in \\mathbb{N}`, it creates a
         formula :math:`\\bigvee_{i=1}^{n}{f_i}`. The list of operands *of size
@@ -1835,7 +1835,7 @@ class Or(Formula):
         return Or(*operands, merge=True) if self.merged else Or(*operands)
 
     def _clausify(self, name_required=True):
-        """
+        r"""
             Disjunction clausification.
 
             If ``name_required`` is ``False``, the method recursively encodes
@@ -1901,7 +1901,7 @@ class Or(Formula):
 #
 #==============================================================================
 class Neg(Formula):
-    """
+    r"""
         Negation. Given a single operand (subformula) :math:`f`, it creates a
         formula :math:`\\neg{f}`. The operand must be passed as an argument to
         the constructor.
@@ -2049,7 +2049,7 @@ class Neg(Formula):
 #
 #==============================================================================
 class Implies(Formula):
-    """
+    r"""
         Implication. Given two operands :math:`f_1` and :math:`f_2`, it
         creates a formula :math:`f_1 \\rightarrow f_2`. The operands must be
         passed to the constructors either as two arguments or two keyword
@@ -2167,7 +2167,7 @@ class Implies(Formula):
         return Implies(left, right)
 
     def _clausify(self, name_required=True):
-        """
+        r"""
             Implication clausification.
 
             If ``name_required`` is ``False``, the method recursively encodes
@@ -2229,7 +2229,7 @@ class Implies(Formula):
 #
 #==============================================================================
 class Equals(Formula):
-    """
+    r"""
         Equivalence. Given a list of operands (subformulas) :math:`f_i`,
         :math:`i \\in \\{1,\\ldots,n\\}, n \\in \\mathbb{N}`, it creates a
         formula :math:`f_1 \\leftrightarrow f_2
@@ -2408,7 +2408,7 @@ class Equals(Formula):
         return Equals(*operands, merge=True) if self.merged else Equals(*operands)
 
     def _clausify(self, name_required=True):
-        """
+        r"""
             Equivalence clausification.
 
             If ``name_required`` is ``False``, the method recursively encodes
@@ -2475,7 +2475,7 @@ class Equals(Formula):
 #
 #==============================================================================
 class XOr(Formula):
-    """
+    r"""
         Exclusive disjunction. Given a list of operands (subformulas)
         :math:`f_i`, :math:`i \\in \\{1,\\ldots,n\\}, n \\in \\mathbb{N}`, it
         creates a formula :math:`f_1 \\oplus f_2 \\oplus\\ldots\\oplus f_n`.
@@ -2753,7 +2753,7 @@ class XOr(Formula):
 #
 #==============================================================================
 class ITE(Formula):
-    """
+    r"""
         If-then-else operator. Given three operands (subformulas) :math:`x`,
         :math:`y`, and :math:`z`, it creates a formula :math:`(x \\rightarrow
         y) \\land (\\neg{x} \\rightarrow z)`. The operands should be passed as
@@ -2888,7 +2888,7 @@ class ITE(Formula):
         return ITE(cond, cons1, cons2)
 
     def _clausify(self, name_required=True):
-        """
+        r"""
             ITE clausification.
 
             If ``name_required`` is ``False``, the method recursively encodes
@@ -3118,7 +3118,7 @@ class CNF(Formula, object):
         self._compute_nv()
 
     def from_string(self, string, comment_lead=['c']):
-        """
+        r"""
             Read a CNF formula from a string. The string should be specified as
             an argument and should be in the DIMACS CNF format. The only
             default argument is ``comment_lead``, which can be used for parsing
@@ -3583,7 +3583,7 @@ class CNF(Formula, object):
         return wcnf
 
     def negate(self, topv=None):
-        """
+        r"""
             Given a CNF formula :math:`\\mathcal{F}`, this method creates a
             CNF formula :math:`\\neg{\\mathcal{F}}`. The negation of the
             formula is encoded to CNF with the use of *auxiliary* Tseitin
@@ -3922,7 +3922,7 @@ class WCNF(object):
                 self.wght.append(w)
 
     def from_string(self, string, comment_lead=['c']):
-        """
+        r"""
             Read a WCNF formula from a string. The string should be specified
             as an argument and should be in the DIMACS CNF format. The only
             default argument is ``comment_lead``, which can be used for parsing
@@ -4336,7 +4336,7 @@ class WCNF(object):
 #
 #==============================================================================
 class CNFPlus(CNF, object):
-    """
+    r"""
         CNF formulas augmented with *native* cardinality constraints.
 
         This class inherits most of the functionality of the :class:`CNF`
@@ -4857,7 +4857,7 @@ class CNFPlus(CNF, object):
 #
 #==============================================================================
 class WCNFPlus(WCNF, object):
-    """
+    r"""
         WCNF formulas augmented with *native* cardinality constraints.
 
         This class inherits most of the functionality of the :class:`WCNF`

--- a/pysat/pb.py
+++ b/pysat/pb.py
@@ -8,7 +8,7 @@
 ##      E-mail: aignatiev@ciencias.ulisboa.pt
 ##
 
-"""
+r"""
     ===============
     List of classes
     ===============
@@ -359,7 +359,7 @@ class PBEnc(object):
     @classmethod
     def leq(cls, lits, weights=None, bound=1, top_id=None, vpool=None,
             encoding=EncType.best):
-        """
+        r"""
             This method can be used for creating a CNF encoding of a LEQ
             (weighted AtMostK) constraint, i.e. of
             :math:`\\sum_{i=1}^{n}{a_i\\cdot x_i}\\leq k`. The resulting set
@@ -407,7 +407,7 @@ class PBEnc(object):
     @classmethod
     def geq(cls, lits, weights=None, bound=1, top_id=None, vpool=None,
             encoding=EncType.best):
-        """
+        r"""
             This method can be used for creating a CNF encoding of a GEQ
             (weighted AtLeastK) constraint, i.e. of
             :math:`\\sum_{i=1}^{n}{a_i\\cdot x_i}\\geq k`. The method shares
@@ -431,7 +431,7 @@ class PBEnc(object):
     @classmethod
     def equals(cls, lits, weights=None, bound=1, top_id=None, vpool=None,
             encoding=EncType.best):
-        """
+        r"""
             This method can be used for creating a CNF encoding of a weighted
             EqualsK constraint, i.e. of :math:`\\sum_{i=1}^{n}{a_i\\cdot x_i}=
             k`. The method shares the arguments and the return type with

--- a/pysat/solvers.py
+++ b/pysat/solvers.py
@@ -8,7 +8,7 @@
 ##      E-mail: aignatiev@ciencias.ulisboa.pt
 ##
 
-"""
+r"""
     ===============
     List of classes
     ===============
@@ -1342,7 +1342,7 @@ class Solver(object):
                 return res
 
     def add_atmost(self, lits, k, weights=[], no_return=True):
-        """
+        r"""
             This method is responsible for adding a new *native* AtMostK (see
             :mod:`pysat.card`) constraint.
 


### PR DESCRIPTION
As in the title. In sufficiently new Python versions, importing the module would raise some warnings about invalid escape sequence.

Only docstrings are changed, so the change should not affect any functionality.