### PR TITLE
use `c++` in glucose421 makefile

### DIFF
--- a/solvers/patches/glucose421.patch
+++ b/solvers/patches/glucose421.patch
@@ -1232,7 +1232,7 @@ diff -Naur build/solvers/glucose421/Makefile solvers/glucose421/Makefile
 +#CXX      := c++
 +#CXXFLAGS := -std=c++11 -fPIC -Wall -Wno-deprecated -fno-strict-aliasing -DINCREMENTAL
 +
-+CXX      := g++
++CXX      := c++
 +CXXFLAGS := -Wall -Wno-parentheses -std=c++11 -D __STDC_LIMIT_MACROS -D __STDC_FORMAT_MACROS -fPIC
 +CXXOPT   := -O3 -DNDEBUG
 +CXXDEBUG := -O0 -g3


### PR DESCRIPTION
I ran into an issue when trying to install pysat from source on MacOS with only clang installed. Glucose421 is the only makefile that explicitly requests `g++` as the Cpp compiler, so it should be safe to change this to use `c++` as for the other solvers, and this fixes my issue.