### PR TITLE
CryptoMinisat: rename conf_limit to confl_limit for consistency

### DIFF
--- a/pysat/solvers.py
+++ b/pysat/solvers.py
@@ -7351,7 +7351,7 @@ class CryptoMinisat(object):
 
             # time and conflicts budget values
             self.time_limit = None
-            self.conf_limit = None
+            self.confl_limit = None
 
     def delete(self):
         """
@@ -7390,11 +7390,11 @@ class CryptoMinisat(object):
 
             self.status, self.model = self.cryptosat.solve(assumptions,
                                                            time_limit=self.time_limit,
-                                                           conf_limit=self.conf_limit)
+                                                           confl_limit=self.confl_limit)
 
             # limit values must be reset again for each new limited call
             self.time_limit = None
-            self.conf_limit = None
+            self.confl_limit = None
 
             if self.use_timer:
                 self.call_time = process_time() - start_time
@@ -7408,7 +7408,7 @@ class CryptoMinisat(object):
         """
 
         if self.cryptosat:
-            self.conf_limit = budget if budget != -1 else None
+            self.confl_limit = budget if budget != -1 else None
 
     def time_budget(self, budget):
         """


### PR DESCRIPTION
This pull request makes a small change to the naming of the conflict budget limit variable in the `pysat/solvers.py` file to ensure consistency and correctness when interacting with the `cryptosat` solver. The variable previously named `conf_limit` has been renamed to `confl_limit` throughout the relevant methods.

### Variable renaming for consistency:

* Renamed all occurrences of `conf_limit` to `confl_limit` in the `new`, `solve_limited`, and `conf_budget` methods to match the expected parameter name for the `cryptosat.solve` function and internal usage. [[1]](diffhunk://#diff-b602e8704257fb8dea208315f7914c47a97fabf9f796dadec5fbb4264659aebdL7354-R7354) [[2]](diffhunk://#diff-b602e8704257fb8dea208315f7914c47a97fabf9f796dadec5fbb4264659aebdL7393-R7397) [[3]](diffhunk://#diff-b602e8704257fb8dea208315f7914c47a97fabf9f796dadec5fbb4264659aebdL7411-R7411)

### Minimal Reproducer (before fix)

```python
from pysat.solvers import Solver

with Solver(name="cryptominisat") as s:
    s.add_clause([1, 2, 3])
    s.solver.conf_budget(10)
    s.solver.time_budget(10)
    s.solve_limited()
```

Observed error:

```python
TypeError: solve() got an unexpected keyword argument 'conf_limit'
```

After this change, the conflict budget is correctly passed as confl_limit, and the solver runs as expected.

### Remark

The intended behavior of interrupting the solver using `solve_limited(expect_interrupt=True)` does not appear to work as expected with the CryptoMiniSat backend. As illustrated by the reproducer, a different approach is currently required to achieve similar behavior. It is unclear whether this is intentional or a limitation of the current wrapper implementation, but it may warrant further investigation.

Minimal reproducer:

```python
from threading import Timer
from pysat.solvers import Solver

def interrupt(s):
    s.interrupt()

max_time = 2
with Solver(name="cryptominisat") as s:
    timer = Timer(max_time, interrupt, [s])
    timer.start()
    s.add_clause([1, 2, 3])
    s.solve_limited(expect_interrupt=True)
```

Observed error:

```python
TypeError: must be real number, not NoneType
```