### PR TITLE
Fix misleading error messages in IPASIR-UP callbacks (#209)

### DIFF
--- a/examples/ipasirup_graphs-bugged.py
+++ b/examples/ipasirup_graphs-bugged.py
@@ -1,0 +1,220 @@
+from pysat.formula import CNF
+from pysat.solvers import Solver
+from pysat.engines import Propagator
+from itertools import combinations
+from math import comb
+from sys import argv,stdout
+
+n = int(argv[1])
+
+vars_ids = {i:I for (i,I) in enumerate(combinations(range(n),2),1)}
+rev_vars = {I:i for (i,I) in enumerate(combinations(range(n),2),1)}
+for i,j in combinations(range(n),2): 
+    rev_vars[j,i] = rev_vars[i,j] # undirected graph = symmetric adjacency matrix
+
+assert all(rev_vars[vars_ids[i]] == i for i in vars_ids)
+
+cnf = CNF()
+
+check_model_calls = 0
+propagate_calls = 0
+
+
+def is_symmetric(A):
+    n = len(A)
+    return all(A[r][c]==A[c][r] for c in range(n) for r in range(n))
+
+def permute(A,perm):
+    assert all( x in range(len(A)) for x in perm)
+    return [[A[r][c] for c in perm] for r in perm]
+
+def combinations_colex_ordered(L,r):
+    return list(reversed([tuple(reversed(I)) for I in combinations(reversed(L),r)]))
+
+def fingerprint(A):
+    return [A[i][j] for i,j in combinations_colex_ordered(range(len(A)),2)]
+
+def minCheck(A,perm=tuple()):
+    if not perm: assert(is_symmetric(A))
+    k = len(perm)
+    n = len(A)
+    A_ = permute(A,range(k)) # restrict to first k rows and columns
+    B_ = permute(A,perm)     # restrict to k rows and columns from pemutation
+    A_fp = fingerprint(A_)
+    B_fp = fingerprint(B_)
+    A_fp = replace(A_fp,None,0) # unset in original are assumed zeros (best case)
+    B_fp = replace(B_fp,None,1) # unset in permuted are assumed ones (worst case)
+    assert(len(A_fp)==len(B_fp))
+
+    if B_fp > A_fp:
+        return
+
+    if k == n:
+        if B_fp < A_fp: # omit identity
+            order_A = combinations_colex_ordered(range(k),2)
+            order_B = combinations_colex_ordered(perm,2)
+            assert all(y == (perm[x[0]],perm[x[1]]) for x,y in zip(order_A,order_B))
+
+            must_be_positive = set()
+            must_be_negative = set()
+            found = False
+            for l in range(len(B_fp)):
+                if B_fp[l] == 0:
+                    must_be_positive.add(rev_vars[order_B[l]])
+                if A_fp[l] == 1:
+                    must_be_negative.add(rev_vars[order_A[l]])
+                if B_fp[l] != A_fp[l]:
+                    assert(B_fp[l] == 0 and A_fp[l] == 1)
+                    yield perm,must_be_positive,must_be_negative
+                    found = True
+                    break
+
+            assert(found)
+    else:
+        assert(k<n)
+        for v in range(n):
+            if v not in perm:
+                yield from minCheck(A,perm+(v,))
+
+def replace(L,oldvalue,newvalue):
+    return [(newvalue if x==oldvalue else x) for x in L]
+
+
+class GraphPropagator(Propagator):
+    def __init__(self, n):
+        super().__init__()
+        self.n = n
+        self.level = 0
+
+        self.assigned_at_level = [set()]     # for each level: list of literals assigned 
+        self.assigned_positive = set()
+        self.assigned_negative = set()
+
+        self.reason = {}                  # reason for literals
+        self.reason_at_level = [set()]    # per level
+        self.queue = []                   # literals queued for propagation 
+        self.pending = []                # clause queued to be added, from check_model()
+
+
+    def adjMatrix(self):
+        A = [[0 for c in range(self.n)] for r in range(self.n)]
+        for i in vars_ids.keys():
+            r,c = vars_ids[i]
+            if i in self.assigned_positive:
+                A[r][c] = A[c][r] = 1
+            elif i in self.assigned_negative:
+                A[r][c] = A[c][r] = 0
+            else:
+                A[r][c] = A[c][r] = None
+        return A
+
+    def setup_observe(self, s):
+        for v in vars_ids:
+            s.observe(v)
+
+    def on_new_level(self):
+        self.level += 1
+        self.assigned_at_level.append(set())
+        self.reason_at_level.append(set())
+        assert len(self.assigned_at_level) == self.level + 1
+        assert len(self.reason_at_level) == self.level + 1
+
+    def on_backtrack(self, to):
+        while self.level > to:
+            for lit in self.assigned_at_level[self.level]:
+                if lit > 0:
+                    self.assigned_positive.discard(lit)
+                else:
+                    self.assigned_negative.discard(-lit)
+            self.assigned_at_level.pop()
+
+            for lit in self.reason_at_level[self.level]:
+                self.reason.pop(lit, None)
+            self.reason_at_level.pop()
+
+            self.level -= 1
+        # BUG: This assert fails at n=6 because CaDiCaL may call
+        # on_assignment (which queues propagations) and then backtrack
+        # before ever calling cb_propagate. See issue #209.
+        assert(not self.queue)
+        self.queue.clear()
+
+    # check partial assignment
+    def on_assignment(self, lit, fixed=False):
+        assert lit not in self.assigned_positive and lit not in self.assigned_negative
+        self.assigned_at_level[self.level].add(lit)
+        if lit > 0:
+            self.assigned_positive.add(lit)
+        else:
+            self.assigned_negative.add(-lit)
+
+        for better_perm,must_be_positive,must_be_negative in minCheck(self.adjMatrix()):
+            assert(must_be_negative.issubset(self.assigned_positive))
+            assert(must_be_positive.issubset(self.assigned_negative))
+            conflict_clause = [+x for x in must_be_positive]+[-x for x in must_be_negative]
+            impl = conflict_clause[0]
+            self.queue.append(impl)
+            self.reason[impl] = conflict_clause
+            # BUG: Missing self.reason_at_level[self.level].add(impl)
+            # Without this, on_backtrack never cleans up stale reasons.
+            # See issue #209.
+            return
+
+    def propagate(self):
+        if not self.queue:
+            return []
+        global propagate_calls
+        propagate_calls += 1
+        lits = self.queue
+        self.queue = []
+        return lits
+
+    def provide_reason(self, lit):
+        r = self.reason.pop(lit)
+        for s in self.reason_at_level:
+            s.discard(lit)
+        return r
+
+    # check full assignment
+    def check_model(self, model):
+        global check_model_calls
+        check_model_calls += 1
+
+        for _ in minCheck(self.adjMatrix()):
+            print("this should never happens! on_assignment should filter all invalid configurations!")
+            self.pending = [-l for l in model]
+            return False
+
+        return True
+
+    def add_clause(self):
+        cls = self.pending
+        self.pending = []
+        return cls
+
+    def decide(self): 
+        return 0
+
+solutions = []
+with Solver(name="cadical195", bootstrap_with=cnf.clauses) as s:
+    p = GraphPropagator(n)
+    s.connect_propagator(p)
+    p.setup_observe(s)
+
+    while s.solve():
+        model = s.get_model()
+        A = [[0 for c in range(n)] for r in range(n)]
+        for i in vars_ids:
+            r,c = vars_ids[i]
+            A[r][c] = A[c][r] = 1
+        solutions.append(A)
+        s.add_clause([-l for l in model])
+
+print(f"{len(solutions)} solutions")
+if len(argv) > 2: print(solutions)
+
+expected_count = [1, 1, 2, 4, 11, 34, 156, 1044, 12346, 274668, 12005168, 1018997864, 165091172592,] # https://oeis.org/A000088
+assert len(solutions) == expected_count[n]
+
+print(f"check_model_calls: {check_model_calls}")
+print(f"propagate_calls: {propagate_calls}")

--- a/examples/ipasirup_graphs.py
+++ b/examples/ipasirup_graphs.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+    Enumerate non-isomorphic graphs on n vertices using SAT + IPASIR-UP.
+
+    This example uses the CaDiCaL 1.9.5 solver with an external propagator
+    (via the IPASIR-UP interface) to enforce canonical form (colex-minimal
+    adjacency matrix under vertex permutations). The propagator detects
+    symmetry violations during search and prunes them with reason clauses.
+
+    Usage:
+        python ipasirup_graphs.py <n>
+
+    Expected counts (OEIS A000088):
+        n=0: 1, n=1: 1, n=2: 2, n=3: 4, n=4: 11, n=5: 34, n=6: 156
+
+    Based on the graph enumeration example from the sat-examples repository,
+    adapted for pysat's single-literal on_assignment API.
+"""
+
+from pysat.formula import CNF
+from pysat.solvers import Solver
+from pysat.engines import Propagator
+from itertools import combinations
+from sys import argv
+
+n = int(argv[1])
+
+# Map edge variables (1-indexed) to vertex pairs and back
+vars_ids = {i: I for (i, I) in enumerate(combinations(range(n), 2), 1)}
+rev_vars = {I: i for (i, I) in enumerate(combinations(range(n), 2), 1)}
+for i, j in combinations(range(n), 2):
+    rev_vars[j, i] = rev_vars[i, j]
+
+assert all(rev_vars[vars_ids[i]] == i for i in vars_ids)
+
+cnf = CNF()
+
+check_model_calls = 0
+propagate_calls = 0
+
+
+def is_symmetric(A):
+    n_ = len(A)
+    return all(A[r][c] == A[c][r] for c in range(n_) for r in range(n_))
+
+
+def permute(A, perm):
+    assert all(x in range(len(A)) for x in perm)
+    return [[A[r][c] for c in perm] for r in perm]
+
+
+def combinations_colex_ordered(L, r):
+    return list(reversed([tuple(reversed(I)) for I in combinations(reversed(L), r)]))
+
+
+def fingerprint(A):
+    return [A[i][j] for i, j in combinations_colex_ordered(range(len(A)), 2)]
+
+
+def replace(L, oldvalue, newvalue):
+    return [(newvalue if x == oldvalue else x) for x in L]
+
+
+def minCheck(A, perm=tuple()):
+    if not perm:
+        assert is_symmetric(A)
+    k = len(perm)
+    n_ = len(A)
+    A_ = permute(A, range(k))
+    B_ = permute(A, perm)
+    A_fp = replace(fingerprint(A_), None, 0)
+    B_fp = replace(fingerprint(B_), None, 1)
+    assert len(A_fp) == len(B_fp)
+
+    if B_fp > A_fp:
+        return
+
+    if k == n_:
+        if B_fp < A_fp:
+            order_A = combinations_colex_ordered(range(k), 2)
+            order_B = combinations_colex_ordered(perm, 2)
+            assert all(y == (perm[x[0]], perm[x[1]]) for x, y in zip(order_A, order_B))
+
+            must_be_positive = set()
+            must_be_negative = set()
+            found = False
+            for l in range(len(B_fp)):
+                if B_fp[l] == 0:
+                    must_be_positive.add(rev_vars[order_B[l]])
+                if A_fp[l] == 1:
+                    must_be_negative.add(rev_vars[order_A[l]])
+                if B_fp[l] != A_fp[l]:
+                    assert B_fp[l] == 0 and A_fp[l] == 1
+                    yield perm, must_be_positive, must_be_negative
+                    found = True
+                    break
+            assert found
+    else:
+        assert k < n_
+        for v in range(n_):
+            if v not in perm:
+                yield from minCheck(A, perm + (v,))
+
+
+class GraphPropagator(Propagator):
+    def __init__(self, n):
+        super().__init__()
+        self.n = n
+        self.level = 0
+
+        self.assigned_at_level = [set()]
+        self.assigned_positive = set()
+        self.assigned_negative = set()
+
+        self.reason = {}
+        self.reason_at_level = [set()]
+        self.queue = []
+        self.pending = []
+
+    def adjMatrix(self):
+        A = [[0 for c in range(self.n)] for r in range(self.n)]
+        for i in vars_ids.keys():
+            r, c = vars_ids[i]
+            if i in self.assigned_positive:
+                A[r][c] = A[c][r] = 1
+            elif i in self.assigned_negative:
+                A[r][c] = A[c][r] = 0
+            else:
+                A[r][c] = A[c][r] = None
+        return A
+
+    def setup_observe(self, s):
+        for v in vars_ids:
+            s.observe(v)
+
+    def on_new_level(self):
+        self.level += 1
+        self.assigned_at_level.append(set())
+        self.reason_at_level.append(set())
+        assert len(self.assigned_at_level) == self.level + 1
+        assert len(self.reason_at_level) == self.level + 1
+
+    def on_backtrack(self, to):
+        while self.level > to:
+            for lit in self.assigned_at_level[self.level]:
+                if lit > 0:
+                    self.assigned_positive.discard(lit)
+                else:
+                    self.assigned_negative.discard(-lit)
+            self.assigned_at_level.pop()
+
+            for lit in self.reason_at_level[self.level]:
+                self.reason.pop(lit, None)
+            self.reason_at_level.pop()
+
+            self.level -= 1
+
+        # CaDiCaL may backtrack before propagate() is called, so the queue
+        # can still have entries. Clear it instead of asserting it's empty.
+        self.queue.clear()
+
+    def on_assignment(self, lit, fixed=False):
+        self.assigned_at_level[self.level].add(lit)
+        if lit > 0:
+            self.assigned_positive.add(lit)
+        else:
+            self.assigned_negative.add(-lit)
+
+        for better_perm, must_be_positive, must_be_negative in minCheck(self.adjMatrix()):
+            assert must_be_negative.issubset(self.assigned_positive)
+            assert must_be_positive.issubset(self.assigned_negative)
+            conflict_clause = [+x for x in must_be_positive] + [-x for x in must_be_negative]
+            impl = conflict_clause[0]
+            self.queue.append(impl)
+            self.reason[impl] = conflict_clause
+            # Track which reason entries were added at this level so
+            # on_backtrack can clean them up and avoid stale reasons.
+            self.reason_at_level[self.level].add(impl)
+            return
+
+    def propagate(self):
+        if not self.queue:
+            return []
+        global propagate_calls
+        propagate_calls += 1
+        lits = self.queue
+        self.queue = []
+        return lits
+
+    def provide_reason(self, lit):
+        r = self.reason.pop(lit)
+        for s in self.reason_at_level:
+            s.discard(lit)
+        return r
+
+    def check_model(self, model):
+        global check_model_calls
+        check_model_calls += 1
+
+        for _ in minCheck(self.adjMatrix()):
+            print("this should never happen! on_assignment should filter all invalid configurations!")
+            self.pending = [-l for l in model]
+            return False
+
+        return True
+
+    def add_clause(self):
+        cls = self.pending
+        self.pending = []
+        return cls
+
+    def decide(self):
+        return 0
+
+
+solutions = []
+with Solver(name="cadical195", bootstrap_with=cnf.clauses) as s:
+    p = GraphPropagator(n)
+    s.connect_propagator(p)
+    p.setup_observe(s)
+
+    while s.solve():
+        model = s.get_model()
+        A = [[0 for c in range(n)] for r in range(n)]
+        for i in vars_ids:
+            r, c = vars_ids[i]
+            if model[i - 1] > 0:
+                A[r][c] = A[c][r] = 1
+        solutions.append(A)
+        s.add_clause([-l for l in model])
+
+print(f"{len(solutions)} solutions")
+
+expected_count = [1, 1, 2, 4, 11, 34, 156, 1044, 12346, 274668, 12005168, 1018997864, 165091172592]
+assert len(solutions) == expected_count[n], f"expected {expected_count[n]}, got {len(solutions)}"
+
+print(f"check_model_calls: {check_model_calls}")
+print(f"propagate_calls: {propagate_calls}")

--- a/solvers/pysolvers.cc
+++ b/solvers/pysolvers.cc
@@ -2944,11 +2944,7 @@ public:
 			return;
 
 		PyObject *status = PyObject_CallMethod(py_prop, "on_assignment", "(ii)", lit, is_fixed, NULL);
-		if (PyErr_Occurred()) {
-			PyErr_Print();
-		}
 		if (status == NULL) {
-			PyErr_SetString(PyExc_RuntimeError, "Could not access method 'on_assignment' in attached propagator.");
 			return;
 		}
 		Py_DECREF(status);
@@ -2966,26 +2962,18 @@ public:
 			return;
 
 		PyObject *status = PyObject_CallMethod(py_prop, "on_new_level", "()", NULL);
-		if (PyErr_Occurred()) {
-			PyErr_Print();
-		}
 		if (status == NULL) {
-			PyErr_SetString(PyExc_RuntimeError, "Could not access method 'on_new_level' in attached propagator.");
 			return;
 		}
 		Py_DECREF(status);
 	}
 	void notify_backtrack (size_t new_level) {
 		if (!passive) {
-			if (PyErr_Occurred()) {
-				PyErr_Print();
-			}
 			propagations_queue.clear(); // we need to clear propagation
 						// queue when backtracking!
 
 			PyObject *status = PyObject_CallMethod(py_prop, "on_backtrack", "(i)", (int)new_level, NULL);
 			if (status == NULL) {
-				PyErr_SetString(PyExc_RuntimeError, "Could not access method 'on_backtrack' in attached propagator.");
 				return;
 			}
 			Py_DECREF(status);
@@ -3012,14 +3000,9 @@ public:
 			PyErr_SetString(PyExc_RuntimeError, "Could not convert from vector to python list.");
 			return false;
 		}
-		if (PyErr_Occurred() == NULL) {
-		}
 		PyObject *status = PyObject_CallMethod(py_prop, "check_model", "(O)", pylist, NULL);
-		if (PyErr_Occurred()) {
-			PyErr_Print();
-		}
 		if (status == NULL) {
-			PyErr_SetString(PyExc_RuntimeError, "Could not access method 'check_model' in attached propagator.");
+			Py_DECREF(pylist);
 			return false;
 		}
 		int res = PyObject_IsTrue(status);
@@ -3042,18 +3025,13 @@ public:
 			return 0;
 
 		PyObject *status = PyObject_CallMethod(py_prop, "decide", "()", NULL);
-		if (PyErr_Occurred()) {
-			PyErr_Print();
-		}
 		if (status == NULL) {
-			PyErr_SetString(PyExc_RuntimeError, "Could not access method 'decide' in attached propagator.");
 			return 0;
 		}
 		int result = pyint_to_cint(status);
 
 		if (PyErr_Occurred() != NULL) {
 			Py_DECREF(status);
-			PyErr_SetString(PyExc_RuntimeError, "Could not construct integer from PyObject.");
 			return 0;
 		}
 		Py_DECREF(status);
@@ -3076,11 +3054,7 @@ public:
 			if (reason_clauses.empty()) {
 				// call python method
 				PyObject *status = PyObject_CallMethod(py_prop, "propagate", "()", NULL);
-				if (PyErr_Occurred()) {
-					PyErr_Print();
-				}
 				if (status == NULL) {
-					PyErr_SetString(PyExc_RuntimeError, "Could not access method 'propagate' in attached propagator.");
 					return 0;
 				}
 
@@ -3150,11 +3124,7 @@ public:
 		if (propagations_queue.empty()) {
 			// call python method
 			PyObject *status = PyObject_CallMethod(py_prop, "propagate", "()", NULL);
-			if (PyErr_Occurred()) {
-				PyErr_Print();
-			}
 			if (status == NULL) {
-				PyErr_SetString(PyExc_RuntimeError, "Could not access method 'propagate' in attached propagator.");
 				return 0;
 			}
 			if (propagate_gives_reason) { // get propagate to give: [[reason_clauses]] where first literal in clause is propagated
@@ -3208,11 +3178,7 @@ public:
 			}
 			// call python method
 			PyObject *status = PyObject_CallMethod(py_prop, "provide_reason", "(i)", propagated_lit, NULL);
-			if (PyErr_Occurred()) {
-				PyErr_Print();
-			}
 			if (status == NULL) {
-				PyErr_SetString(PyExc_RuntimeError, "Could not access method 'provide_reason' in attached propagator.");
 				return 0;
 			}
 			// put into queue
@@ -3265,11 +3231,7 @@ public:
 	// TODO check if this works and polish it up
 	bool py_callmethod_to_vec (const char *name,std::vector<int>& outvect_int, std::vector<PyObject*>& outvect_pyobj) {
 		PyObject *status = PyObject_CallMethod(py_prop, "add_clause", "()", NULL);
-		if (PyErr_Occurred()) {
-			PyErr_Print();
-		}
 		if (status == NULL) {
-			PyErr_SetString(PyExc_RuntimeError, "Could not access method 'add_clause' in attached propagator.");
 			return false;
 		}
 		// put into queue
@@ -3325,7 +3287,6 @@ public:
 			}
 			// query has_clause
 			if (!py_callmethod_to_vec("add_clause",add_clause_queue,ext_clauses)) {
-				PyErr_Print();
 				return false;
 			}
 			// if no clause, return false
@@ -3333,11 +3294,7 @@ public:
 			return !(add_clause_queue.empty());
 		}
 		PyObject *status = PyObject_CallMethod(py_prop, "has_clause", "()", NULL);
-		if (PyErr_Occurred()) {
-			PyErr_Print();
-		}
 		if (status == NULL) {
-			PyErr_SetString(PyExc_RuntimeError, "Could not access method 'has_clause' in attached propagator.");
 			return false;
 		}
 		int res = PyObject_IsTrue(status);
@@ -3380,7 +3337,6 @@ public:
 			Py_DECREF(sel);
 		} else if (add_clause_queue.empty()) { // otherwise, call add_clause
 			if (!py_callmethod_to_vec("add_clause",add_clause_queue,ext_clauses)) { // this should already load a clause into add_clause_queue
-				PyErr_Print();
 				return 0;
 			}
 		}


### PR DESCRIPTION
With the help of Claude, I managed to fix two tricky issues in pysat's IPASIR-UP interface related to #209.

**The C++ wrapper bug**: When a Python callback (e.g. on_backtrack) raises an exception, `PyObject_CallMethod` returns NULL with the real exception already set. The old code called `PyErr_Print()` which printed the exception to stderr and cleared it, then set a new generic `RuntimeError("Could not access method...")`. This made it nearly impossible to find the actual root cause — you'd only see a cascade of misleading "Could not access method" messages. Without seeing the real exception, I couldn't identify the bug in my Python script.

**The Python script bugs**: Once the real exceptions became visible, two bugs in the example propagator were easy to spot:
1. `on_assignment` was missing `self.reason_at_level[self.level].add(impl)`, so on_backtrack never cleaned up stale reason entries
2. `assert(not self.queue)` in on_backtrack is too strict — CaDiCaL may call on_assignment (which queues propagations) and then backtrack before ever calling cb_propagate, so the queue can legitimately be non-empty

**The effect**: The program still found the correct 156 solutions even with the bugs, but the propagator was less efficient — invalid partial assignments weren't caught early, leading to 229 propagate calls instead of 219. More importantly, it produced a wall of misleading error messages on stderr that hid the real problem.

**Reproducing the bug**: `examples/ipasirup_graphs-bugged.py` contains the original buggy propagator. It demonstrates both issues:
- Without this patch (old `pysolvers.cc`): the bugged script runs to completion at n=6 with 156 solutions but prints a long cascade of RuntimeError: Could not access method ... messages — the real AssertionError is hidden
- With this patch (fixed `pysolvers.cc`): the bugged script correctly fails with AssertionError: assert(not self.queue) — making the root cause immediately visible

The fixed script `examples/ipasirup_graphs.py` runs cleanly (before and after the patch):
```$ python examples/ipasirup_graphs.py 6
156 solutions
check_model_calls: 156
propagate_calls: 219
```

