### PR TITLE
include headers of formula C-extension in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ recursive-include cardenc *.hh
 include solvers/prepare.py
 recursive-include solvers *.patch
 recursive-include solvers *.zip *.tar.gz
+recursive-include formula *.hh


### PR DESCRIPTION
The headers of the recently added formula C-extension are not included in the source distribution on PyPI, so currently PySAT can't be built from (PyPI) source.

After this change, running `python setup.py sdist && pip install dist/python_sat-1.9.dev4.tar.gz` succeeds for me.