### PR TITLE
ci: enable pyodide build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,15 +49,15 @@ jobs:
           # - os: ios
           #   runs-on: macos-latest
           #   platform: ios
-          # - os: pyodide
-          #   runs-on: ubuntu-latest
-          #   platform: pyodide
+          - os: pyodide
+            runs-on: ubuntu-latest
+            platform: pyodide
 
     steps:
       - uses: actions/checkout@v5
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1.4
+        uses: pypa/cibuildwheel@v4.1.0
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
           CIBW_ARCHS: ${{ matrix.archs || 'auto' }}


### PR DESCRIPTION
cibuildwheel 4.1.0 now supports building pyodide (pyemscripten) wheels and also [PyPI now accepts Pyodide wheels](https://discuss.python.org/t/pep-783-emscripten-packaging-is-accepted/107393).

After this is merged, we are planning to remove [python-sat from pyodide-recipes](https://github.com/pyodide/pyodide-recipes/blob/main/packages/python-sat/meta.yaml)