### PR TITLE
adding new custom button to toggle sidebar on phones

### DIFF
--- a/docs/_templates/custom-search.html
+++ b/docs/_templates/custom-search.html
@@ -1,0 +1,12 @@
+{% include "search-button-field.html" %}
+<script>
+    (function() {
+        var btn = document.currentScript.previousElementSibling;
+
+        btn.addEventListener("click", function() {
+            var toggle = document.querySelector(".primary-toggle");
+            if(!toggle.checkVisibility()) return;
+            toggle.click();
+        }, true);
+    })();
+</script>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,7 @@ html_theme_options = {
     "show_nav_level": 2,
     "navbar_start": ["navbar-logo"],
     "navbar_center": ["version"],
+    "navbar_persistent": ["custom-search"],
     "navbar_end": ["navbar-icon-links"],
     "icon_links": [
         {


### PR DESCRIPTION
Search button on mobile
I was looking at the search button on [https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/search.html](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/search.html) 

<img width="1232" height="640" alt="image" src="https://github.com/user-attachments/assets/7be403d6-6c0e-48a4-9b60-5df7a054ae04" />

To keep the current behavior we will need to modify the button. Custom search is the same search-button with a new function, what i am checking is if the button to open the sidebar is visible then "search" will toggle it.
I think another solution could be removing the search button from the sidebar, but then the sidebar would be empty and it would disappear. 